### PR TITLE
feat: use smart pointers

### DIFF
--- a/NativeScript/NativeScript.mm
+++ b/NativeScript/NativeScript.mm
@@ -19,7 +19,7 @@ using namespace tns;
 
 @implementation NativeScript
 
-static Runtime* runtime_ = nullptr;
+static std::shared_ptr<Runtime> runtime_;
 
 + (void)start:(Config*)config {
     RuntimeConfig.BaseDir = [config.BaseDir UTF8String];
@@ -29,7 +29,7 @@ static Runtime* runtime_ = nullptr;
     RuntimeConfig.LogToSystemConsole = [config LogToSystemConsole];
 
     Runtime::Initialize();
-    runtime_ = new Runtime();
+    runtime_ = std::make_shared<Runtime>();
 
     std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
     runtime_->Init();
@@ -38,7 +38,7 @@ static Runtime* runtime_ = nullptr;
     printf("Runtime initialization took %llims\n", duration);
 
     if (config.IsDebug) {
-        v8_inspector::JsV8InspectorClient* inspectorClient = new v8_inspector::JsV8InspectorClient(runtime_);
+        v8_inspector::JsV8InspectorClient* inspectorClient = new v8_inspector::JsV8InspectorClient(runtime_.get());
         inspectorClient->init();
         inspectorClient->registerModules();
         inspectorClient->connect([config ArgumentsCount], [config Arguments]);
@@ -47,6 +47,8 @@ static Runtime* runtime_ = nullptr;
     runtime_->RunMainScript();
 
     tns::Tasks::Drain();
+
+    runtime_.reset();
 }
 
 + (bool)liveSync {

--- a/NativeScript/inspector/JsV8InspectorClient.mm
+++ b/NativeScript/inspector/JsV8InspectorClient.mm
@@ -174,9 +174,9 @@ void JsV8InspectorClient::runMessageLoopOnPause(int contextGroupId) {
             this->dispatchMessage(message);
         }
 
-        Platform* platform = tns::Runtime::GetPlatform();
+        std::unique_ptr<Platform> platform = tns::Runtime::GetPlatform();
         Isolate* isolate = runtime_->GetIsolate();
-        while (platform::PumpMessageLoop(platform, isolate)) {
+        while (platform::PumpMessageLoop(platform.get(), isolate)) {
         }
     }
 

--- a/NativeScript/inspector/v8-inspector-platform.h
+++ b/NativeScript/inspector/v8-inspector-platform.h
@@ -94,8 +94,8 @@ public:
         DefaultPlatform::CallDelayedOnWorkerThread(move(task), 0);
     }
 
-    static Platform* CreateDefaultPlatform() {
-        return NewDefaultPlatform().release();
+    static std::unique_ptr<Platform> CreateDefaultPlatform() {
+        return NewDefaultPlatform();
     }
 private:
     static unique_ptr<Platform> NewDefaultPlatform() {

--- a/NativeScript/runtime/ArgConverter.h
+++ b/NativeScript/runtime/ArgConverter.h
@@ -12,7 +12,7 @@ class ArgConverter;
 
 struct MethodCallbackWrapper {
 public:
-    MethodCallbackWrapper(v8::Isolate* isolate, v8::Persistent<v8::Value>* callback, const uint8_t initialParamIndex, const uint8_t paramsCount, const TypeEncoding* typeEncoding)
+    MethodCallbackWrapper(v8::Isolate* isolate, std::shared_ptr<v8::Persistent<v8::Value>> callback, const uint8_t initialParamIndex, const uint8_t paramsCount, const TypeEncoding* typeEncoding)
         : isolate_(isolate),
           callback_(callback),
           initialParamIndex_(initialParamIndex),
@@ -20,7 +20,7 @@ public:
           typeEncoding_(typeEncoding) {
     }
     v8::Isolate* isolate_;
-    v8::Persistent<v8::Value>* callback_;
+    std::shared_ptr<v8::Persistent<v8::Value>> callback_;
     const uint8_t initialParamIndex_;
     const uint8_t paramsCount_;
     const TypeEncoding* typeEncoding_;
@@ -32,8 +32,8 @@ public:
     static v8::Local<v8::Value> Invoke(v8::Isolate* isolate, Class klass, v8::Local<v8::Object> receiver, const std::vector<v8::Local<v8::Value>> args, const MethodMeta* meta, bool isMethodCallback);
     static v8::Local<v8::Value> ConvertArgument(v8::Isolate* isolate, BaseDataWrapper* wrapper);
     static v8::Local<v8::Value> CreateJsWrapper(v8::Isolate* isolate, BaseDataWrapper* wrapper, v8::Local<v8::Object> receiver);
-    static v8::Local<v8::Object> CreateEmptyObject(v8::Local<v8::Context> context);
-    static v8::Local<v8::Object> CreateEmptyStruct(v8::Local<v8::Context> context);
+    static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyObject(v8::Local<v8::Context> context);
+    static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyStruct(v8::Local<v8::Context> context);
     static const Meta* FindMeta(Class klass);
     static const Meta* GetMeta(std::string name);
     static const ProtocolMeta* FindProtocolMeta(Protocol* protocol);
@@ -42,7 +42,7 @@ public:
     static void ConstructObject(v8::Isolate* isolate, const v8::FunctionCallbackInfo<v8::Value>& info, Class klass, const InterfaceMeta* interfaceMeta = nullptr);
 private:
     static v8::Local<v8::Function> CreateEmptyInstanceFunction(v8::Isolate* isolate, v8::GenericNamedPropertyGetterCallback propertyGetter = nullptr, v8::GenericNamedPropertySetterCallback propertySetter = nullptr);
-    static v8::Local<v8::Object> CreateEmptyInstance(v8::Local<v8::Context> context, v8::Persistent<v8::Function>* ctorFunc);
+    static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyInstance(v8::Local<v8::Context> context, v8::Persistent<v8::Function>* ctorFunc);
     static void FindMethodOverloads(Class klass, std::string methodName, MemberType type, std::vector<const MethodMeta*>& overloads);
     static const MethodMeta* FindInitializer(v8::Isolate* isolate, Class klass, const InterfaceMeta* interfaceMeta, const v8::FunctionCallbackInfo<v8::Value>& info, std::vector<v8::Local<v8::Value>>& args);
     static bool CanInvoke(v8::Isolate* isolate, const TypeEncoding* typeEncoding, v8::Local<v8::Value> arg);

--- a/NativeScript/runtime/Caches.cpp
+++ b/NativeScript/runtime/Caches.cpp
@@ -5,95 +5,37 @@ using namespace v8;
 namespace tns {
 
 Caches::~Caches() {
-    for (auto pair: this->Prototypes) {
-        delete pair.second;
-    }
     this->Prototypes.clear();
-
-    for (auto pair: this->ClassPrototypes) {
-        delete pair.second;
-    }
     this->ClassPrototypes.clear();
-
-    for (auto pair: this->CtorFuncTemplates) {
-        delete pair.second;
-    }
     this->CtorFuncTemplates.clear();
-
-    for (auto pair: this->CtorFuncs) {
-        delete pair.second;
-    }
     this->CtorFuncs.clear();
-
-    for (auto pair: this->ProtocolCtorFuncs) {
-        delete pair.second;
-    }
     this->ProtocolCtorFuncs.clear();
-
-    for (auto pair: this->Instances) {
-        delete pair.second;
-    }
-    this->Instances.clear();
-
-    for (auto pair: this->PointerInstances) {
-        delete pair.second;
-    }
-    this->PointerInstances.clear();
-
-    for (auto pair: this->StructConstructorFunctions) {
-        delete pair.second;
-    }
     this->StructConstructorFunctions.clear();
-
-    for (auto pair: this->PrimitiveInteropTypes) {
-        delete pair.second;
-    }
     this->PrimitiveInteropTypes.clear();
-
-    for (auto pair: this->CFunctions) {
-        delete pair.second;
-    }
     this->CFunctions.clear();
 
-    for (auto pair: this->StructInstances) {
-        delete pair.second;
-    }
+    this->Instances.clear();
     this->StructInstances.clear();
-
-    delete this->ToStringFunc;
-    delete this->EmptyObjCtorFunc;
-    delete this->EmptyStructCtorFunc;
-    delete this->SliceFunc;
-    delete this->OriginalExtendsFunc;
-    delete this->WeakRefGetterFunc;
-    delete this->WeakRefClearFunc;
-    delete this->InteropReferenceCtorFunc;
-    delete this->PointerCtorFunc;
-    delete this->FunctionReferenceCtorFunc;
-    delete this->SmartJSONStringifyFunc;
+    this->PointerInstances.clear();
 }
 
-Caches* Caches::Get(Isolate* isolate) {
-    Caches* caches = Caches::perIsolateCaches_.Get(isolate);
-    if (caches == nullptr) {
-        caches = new Caches();
-        Caches::perIsolateCaches_.Insert(isolate, caches);
+std::shared_ptr<Caches> Caches::Get(Isolate* isolate) {
+    std::shared_ptr<Caches> cache = Caches::perIsolateCaches_.Get(isolate);
+    if (cache == nullptr) {
+        cache = std::make_shared<Caches>();
+        Caches::perIsolateCaches_.Insert(isolate, cache);
     }
 
-    return caches;
+    return cache;
 }
 
 void Caches::Remove(v8::Isolate* isolate) {
-    Caches* caches = nullptr;
-    Caches::perIsolateCaches_.Remove(isolate, caches);
-    if (caches != nullptr) {
-        delete caches;
-    }
+    Caches::perIsolateCaches_.Remove(isolate);
 }
 
-ConcurrentMap<Isolate*, Caches*> Caches::perIsolateCaches_;
+ConcurrentMap<Isolate*, std::shared_ptr<Caches>> Caches::perIsolateCaches_;
 
 ConcurrentMap<std::string, const Meta*> Caches::Metadata;
-ConcurrentMap<int, Caches::WorkerState*> Caches::Workers;
+ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>> Caches::Workers;
 
 }

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -41,15 +41,15 @@ private:
 
     struct PropertyCallbackContext {
     public:
-        PropertyCallbackContext(v8::Isolate* isolate, v8::Persistent<v8::Function>* callback, v8::Persistent<v8::Object>* implementationObject, const PropertyMeta* meta)
+        PropertyCallbackContext(v8::Isolate* isolate, std::shared_ptr<v8::Persistent<v8::Function>> callback, std::shared_ptr<v8::Persistent<v8::Object>> implementationObject, const PropertyMeta* meta)
             : isolate_(isolate),
               callback_(callback),
               implementationObject_(implementationObject),
               meta_(meta) {
             }
         v8::Isolate* isolate_;
-        v8::Persistent<v8::Function>* callback_;
-        v8::Persistent<v8::Object>* implementationObject_;
+        std::shared_ptr<v8::Persistent<v8::Function>> callback_;
+        std::shared_ptr<v8::Persistent<v8::Object>> implementationObject_;
         const PropertyMeta* meta_;
     };
 };

--- a/NativeScript/runtime/ConcurrentMap.h
+++ b/NativeScript/runtime/ConcurrentMap.h
@@ -37,13 +37,9 @@ public:
         return it != this->container_.end();
     }
 
-    void Remove(TKey& key, TValue& removedElement) {
+    void Remove(TKey& key) {
         std::lock_guard<std::mutex> writerLock(this->containerMutex_);
-        auto it = this->container_.find(key);
-        if (it != this->container_.end()) {
-            removedElement = it->second;
-            this->container_.erase(it);
-        }
+        this->container_.erase(key);
     }
 
     ConcurrentMap() = default;

--- a/NativeScript/runtime/Console.cpp
+++ b/NativeScript/runtime/Console.cpp
@@ -174,7 +174,7 @@ void Console::TimeCallback(const FunctionCallbackInfo<Value>& args) {
         label = tns::ToString(isolate, labelString);
     }
 
-    Caches* cache = Caches::Get(isolate);
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
 
     auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
     double timeStamp = nano.time_since_epoch().count();
@@ -196,7 +196,7 @@ void Console::TimeEndCallback(const FunctionCallbackInfo<Value>& args) {
         label = tns::ToString(isolate, labelString);
     }
 
-    Caches* cache = Caches::Get(isolate);
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
     auto itTimersMap = cache->Timers.find(label);
     if (itTimersMap == cache->Timers.end()) {
         std::string warning = std::string("No such label '" + label + "' for console.timeEnd()");

--- a/NativeScript/runtime/FunctionReference.cpp
+++ b/NativeScript/runtime/FunctionReference.cpp
@@ -16,7 +16,7 @@ void FunctionReference::Register(Isolate* isolate, Local<Object> interop) {
 
 Local<v8::Function> FunctionReference::GetFunctionReferenceCtorFunc(Isolate* isolate) {
     auto cache = Caches::Get(isolate);
-    Persistent<v8::Function>* poFunctionReferenceCtor = cache->FunctionReferenceCtorFunc;
+    Persistent<v8::Function>* poFunctionReferenceCtor = cache->FunctionReferenceCtorFunc.get();
     if (poFunctionReferenceCtor != nullptr) {
         return poFunctionReferenceCtor->Get(isolate);
     }
@@ -34,7 +34,7 @@ Local<v8::Function> FunctionReference::GetFunctionReferenceCtorFunc(Isolate* iso
 
     tns::SetValue(isolate, ctorFunc, new FunctionReferenceTypeWrapper());
 
-    cache->FunctionReferenceCtorFunc = new Persistent<v8::Function>(isolate, ctorFunc);
+    cache->FunctionReferenceCtorFunc = std::make_unique<Persistent<v8::Function>>(isolate, ctorFunc);
 
     return ctorFunc;
 }
@@ -46,7 +46,7 @@ void FunctionReference::FunctionReferenceConstructorCallback(const FunctionCallb
     Isolate* isolate = info.GetIsolate();
 
     Local<v8::Function> arg = info[0].As<v8::Function>();
-    Persistent<v8::Value>* poArg = ObjectManager::Register(isolate, arg);
+    std::shared_ptr<Persistent<v8::Value>> poArg = ObjectManager::Register(isolate, arg);
     FunctionReferenceWrapper* wrapper = new FunctionReferenceWrapper(poArg);
     tns::SetValue(isolate, arg, wrapper);
     info.GetReturnValue().Set(arg);

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -363,7 +363,7 @@ Local<v8::String> tns::JsonStringifyObject(Isolate* isolate, Local<Value> value,
 }
 
 Local<v8::Function> tns::GetSmartJSONStringifyFunction(Isolate* isolate) {
-    Caches* caches = Caches::Get(isolate);
+    std::shared_ptr<Caches> caches = Caches::Get(isolate);
     if (caches->SmartJSONStringifyFunc != nullptr) {
         return caches->SmartJSONStringifyFunc->Get(isolate);
     }
@@ -410,7 +410,7 @@ Local<v8::Function> tns::GetSmartJSONStringifyFunction(Isolate* isolate) {
 
     Local<v8::Function> smartStringifyFunction = result.As<v8::Function>();
 
-    caches->SmartJSONStringifyFunc = new Persistent<v8::Function>(isolate, smartStringifyFunction);
+    caches->SmartJSONStringifyFunc = std::make_unique<Persistent<v8::Function>>(isolate, smartStringifyFunction);
 
     return smartStringifyFunction;
 }

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -22,7 +22,7 @@ public:
     static v8::Local<v8::Value> CallFunction(v8::Isolate* isolate, const MethodMeta* meta, id target, Class clazz, const std::vector<v8::Local<v8::Value>> args, bool callSuper);
     static v8::Local<v8::Value> CallFunction(v8::Isolate* isolate, const FunctionMeta* meta, const std::vector<v8::Local<v8::Value>> args);
     static v8::Local<v8::Value> CallFunction(v8::Isolate* isolate, void* functionPointer, const TypeEncoding* typeEncoding, const std::vector<v8::Local<v8::Value>> args);
-    static v8::Local<v8::Value> GetResult(v8::Isolate* isolate, const TypeEncoding* typeEncoding, BaseCall* call, bool marshalToPrimitive, bool copyStructs = false, bool isStructMember = false);
+    static v8::Local<v8::Value> GetResult(v8::Isolate* isolate, const TypeEncoding* typeEncoding, BaseCall* call, bool marshalToPrimitive, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct = nullptr, bool isStructMember = false);
     static void SetStructPropertyValue(v8::Isolate* isolate, StructWrapper* wrapper, StructField field, v8::Local<v8::Value> value);
     static void InitializeStruct(v8::Isolate* isolate, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer);
     static void WriteValue(v8::Isolate* isolate, const TypeEncoding* typeEncoding, void* dest, v8::Local<v8::Value> arg);
@@ -41,7 +41,7 @@ private:
     static void RegisterSizeOfFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
     static void SetFFIParams(v8::Isolate* isolate, const TypeEncoding* typeEncoding, FFICall* call, const int argsCount, const int initialParameterIndex, const std::vector<v8::Local<v8::Value>> args);
     static v8::Local<v8::Array> ToArray(v8::Isolate* isolate, v8::Local<v8::Object> object);
-    static v8::Local<v8::Value> StructToValue(v8::Isolate* isolate, void* result, StructInfo structInfo, bool copyStructs);
+    static v8::Local<v8::Value> StructToValue(v8::Isolate* isolate, void* result, StructInfo structInfo, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct);
     static const TypeEncoding* CreateEncoding(BinaryTypeEncodingType type);
     static v8::Local<v8::Value> HandleOf(v8::Isolate* isolate, v8::Local<v8::Value> value);
     static v8::Local<v8::Value> CallFunctionInternal(v8::Isolate* isolate, bool isPrimitiveFunction, void* functionPointer, const TypeEncoding* typeEncoding, const std::vector<v8::Local<v8::Value>> args, id target, Class clazz, SEL selector, bool callSuper, MetaType metaType, bool provideErrorOurParameter = false);

--- a/NativeScript/runtime/InteropTypes.mm
+++ b/NativeScript/runtime/InteropTypes.mm
@@ -61,7 +61,7 @@ void Interop::RegisterInteropTypes(Isolate* isolate) {
 }
 
 Local<Object> Interop::GetInteropType(Isolate* isolate, std::string name) {
-    Caches* cache = Caches::Get(isolate);
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
     auto it = cache->PrimitiveInteropTypes.find(name);
     if (it == cache->PrimitiveInteropTypes.end()) {
         // TODO: throw error for unknown primitive type
@@ -91,11 +91,10 @@ void Interop::RegisterInteropType(Isolate* isolate, Local<Object> types, std::st
     tns::SetValue(isolate, result, wrapper);
     bool success = types->Set(context, tns::ToV8String(isolate, name), result).FromMaybe(false);
 
-    Caches* cache = Caches::Get(isolate);
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
     auto it = cache->PrimitiveInteropTypes.find(name);
     if (it == cache->PrimitiveInteropTypes.end()) {
-        Persistent<Object>* poResult = new Persistent<Object>(isolate, result);
-        cache->PrimitiveInteropTypes.emplace(name, poResult);
+        cache->PrimitiveInteropTypes.emplace(name, std::make_unique<Persistent<Object>>(isolate, result));
     }
 
     assert(success);

--- a/NativeScript/runtime/MetadataBuilder.h
+++ b/NativeScript/runtime/MetadataBuilder.h
@@ -17,7 +17,7 @@ public:
     static v8::Local<v8::Function> GetOrCreateStructCtorFunction(v8::Isolate* isolate, StructInfo structInfo);
     static void StructPropertyGetterCallback(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void StructPropertySetterCallback(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
-    static v8::Persistent<v8::Function>* CreateToStringFunction(v8::Isolate* isolate);
+    static void CreateToStringFunction(v8::Isolate* isolate);
 private:
     static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplateInternal(v8::Isolate* isolate, const BaseClassMeta* meta, std::unordered_map<std::string, uint8_t>& instanceMembers, std::unordered_map<std::string, uint8_t>& staticMembers);
     static void GlobalPropertyGetter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);

--- a/NativeScript/runtime/ObjectManager.h
+++ b/NativeScript/runtime/ObjectManager.h
@@ -8,13 +8,15 @@ namespace tns {
 class ObjectManager;
 
 struct ObjectWeakCallbackState {
-    ObjectWeakCallbackState(v8::Persistent<v8::Value>* target) : target_(target) { }
-    v8::Persistent<v8::Value>* target_;
+    ObjectWeakCallbackState(std::shared_ptr<v8::Persistent<v8::Value>> target) : target_(target) {
+    }
+
+    std::shared_ptr<v8::Persistent<v8::Value>> target_;
 };
 
 class ObjectManager {
 public:
-    static v8::Persistent<v8::Value>* Register(v8::Isolate* isolate, const v8::Local<v8::Value> obj);
+    static std::shared_ptr<v8::Persistent<v8::Value>> Register(v8::Isolate* isolate, const v8::Local<v8::Value> obj);
     static void FinalizerCallback(const v8::WeakCallbackInfo<ObjectWeakCallbackState>& data);
 private:
     static bool DisposeValue(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/NativeScript/runtime/Pointer.cpp
+++ b/NativeScript/runtime/Pointer.cpp
@@ -29,7 +29,7 @@ Local<Value> Pointer::NewInstance(Isolate* isolate, void* handle) {
 
 Local<v8::Function> Pointer::GetPointerCtorFunc(Isolate* isolate) {
     auto cache = Caches::Get(isolate);
-    Persistent<v8::Function>* pointerCtorFunc = cache->PointerCtorFunc;
+    Persistent<v8::Function>* pointerCtorFunc = cache->PointerCtorFunc.get();
     if (pointerCtorFunc != nullptr) {
         return pointerCtorFunc->Get(isolate);
     }
@@ -58,7 +58,7 @@ Local<v8::Function> Pointer::GetPointerCtorFunc(Isolate* isolate) {
     Pointer::RegisterToDecimalStringMethod(isolate, prototype);
     Pointer::RegisterToNumberMethod(isolate, prototype);
 
-    cache->PointerCtorFunc = new Persistent<v8::Function>(isolate, ctorFunc);
+    cache->PointerCtorFunc = std::make_unique<Persistent<v8::Function>>(isolate, ctorFunc);
 
     return ctorFunc;
 }
@@ -106,7 +106,7 @@ void Pointer::PointerConstructorCallback(const FunctionCallbackInfo<Value>& info
 
         ObjectManager::Register(isolate, info.This());
 
-        cache->PointerInstances.insert(std::make_pair(ptr, new Persistent<Object>(isolate, info.This())));
+        cache->PointerInstances.emplace(ptr, std::make_shared<Persistent<Object>>(isolate, info.This()));
     } catch (NativeScriptException& ex) {
         ex.ReThrowToV8(isolate);
     }

--- a/NativeScript/runtime/Reference.cpp
+++ b/NativeScript/runtime/Reference.cpp
@@ -33,7 +33,7 @@ Local<Value> Reference::FromPointer(Isolate* isolate, Local<Value> type, void* h
 
 Local<v8::Function> Reference::GetInteropReferenceCtorFunc(Isolate* isolate) {
     auto cache = Caches::Get(isolate);
-    Persistent<v8::Function>* interopReferenceCtor = cache->InteropReferenceCtorFunc;
+    Persistent<v8::Function>* interopReferenceCtor = cache->InteropReferenceCtorFunc.get();
     if (interopReferenceCtor != nullptr) {
         return interopReferenceCtor->Get(isolate);
     }
@@ -58,7 +58,7 @@ Local<v8::Function> Reference::GetInteropReferenceCtorFunc(Isolate* isolate) {
     Local<Object> prototype = prototypeValue.As<Object>();
     Reference::RegisterToStringMethod(isolate, prototype);
 
-    cache->InteropReferenceCtorFunc = new Persistent<v8::Function>(isolate, ctorFunc);
+    cache->InteropReferenceCtorFunc = std::make_unique<Persistent<v8::Function>>(isolate, ctorFunc);
 
     return ctorFunc;
 }

--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -37,14 +37,14 @@ public:
         return currentRuntime_->WorkerId() > 0;
     }
 
-    static v8::Platform* GetPlatform() {
-        return platform_;
+    static std::unique_ptr<v8::Platform> GetPlatform() {
+        return std::move(platform_);
     }
 
     static id GetAppConfigValue(std::string key);
 private:
     static thread_local Runtime* currentRuntime_;
-    static v8::Platform* platform_;
+    static std::unique_ptr<v8::Platform> platform_;
     static bool mainThreadInitialized_;
 
     void DefineGlobalObject(v8::Local<v8::Context> context);
@@ -54,7 +54,7 @@ private:
     void DefineTimeMethod(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate);
     static void PerformanceNowCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
     v8::Isolate* isolate_;
-    ModuleInternal moduleInternal_;
+    std::unique_ptr<ModuleInternal> moduleInternal_;
     int workerId_;
 };
 

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -66,7 +66,7 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
 
         WorkerWrapper* worker = new WorkerWrapper(isolate, Worker::OnMessageCallback);
         tns::SetValue(isolate, thiz, worker);
-        Persistent<Value>* poWorker = ObjectManager::Register(isolate, thiz);
+        std::shared_ptr<Persistent<Value>> poWorker = ObjectManager::Register(isolate, thiz);
 
         std::function<Isolate* ()> func([worker, workerPath]() {
             tns::Runtime* runtime = new tns::Runtime();
@@ -88,7 +88,7 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
 
         worker->Start(poWorker, func);
 
-        Caches::WorkerState* state = new Caches::WorkerState(isolate, poWorker, worker);
+        std::shared_ptr<Caches::WorkerState> state = std::make_shared<Caches::WorkerState>(isolate, poWorker, worker);
         int workerId = worker->Id();
         Caches::Workers.Insert(workerId, state);
     } catch (NativeScriptException& ex) {
@@ -111,7 +111,7 @@ void Worker::PostMessageToMainCallback(const FunctionCallbackInfo<Value>& info) 
 
         Runtime* runtime = Runtime::GetCurrentRuntime();
         int workerId = runtime->WorkerId();
-        Caches::WorkerState* state = Caches::Workers.Get(workerId);
+        std::shared_ptr<Caches::WorkerState> state = Caches::Workers.Get(workerId);
         assert(state != nullptr);
         WorkerWrapper* worker = static_cast<WorkerWrapper*>(state->UserData());
         if (!worker->IsRunning()) {
@@ -201,7 +201,7 @@ void Worker::OnMessageCallback(Isolate* isolate, Local<Value> receiver, std::str
 void Worker::CloseWorkerCallback(const FunctionCallbackInfo<Value>& info) {
     Runtime* runtime = Runtime::GetCurrentRuntime();
     int workerId = runtime->WorkerId();
-    Caches::WorkerState* state = Caches::Workers.Get(workerId);
+    std::shared_ptr<Caches::WorkerState> state = Caches::Workers.Get(workerId);
     assert(state != nullptr);
     WorkerWrapper* worker = static_cast<WorkerWrapper*>(state->UserData());
 

--- a/NativeScript/runtime/WorkerWrapper.mm
+++ b/NativeScript/runtime/WorkerWrapper.mm
@@ -50,7 +50,7 @@ void WorkerWrapper::PostMessage(std::string message) {
     }
 }
 
-void WorkerWrapper::Start(Persistent<Value>* poWorker, std::function<Isolate* ()> func) {
+void WorkerWrapper::Start(std::shared_ptr<Persistent<Value>> poWorker, std::function<Isolate* ()> func) {
     this->poWorker_ = poWorker;
     nextId_++;
     this->workerId_ = nextId_;

--- a/TestFixtures/Marshalling/TNSRecords.h
+++ b/TestFixtures/Marshalling/TNSRecords.h
@@ -133,6 +133,7 @@ typedef struct StructWithVectorAndDouble {
 } StructWithVectorAndDouble;
 
 TNSVerySimpleStruct getSimpleStruct();
+CGRect getRectStruct();
 TNSComplexStruct getComplexStruct();
 matrix_float2x2 getMatrixFloat2x2();
 matrix_float2x3 getMatrixFloat2x3();

--- a/TestFixtures/Marshalling/TNSRecords.m
+++ b/TestFixtures/Marshalling/TNSRecords.m
@@ -23,6 +23,11 @@ NestedSimpleStruct getNestedStruct() {
     return simpleStruct;
 }
 
+CGRect getRectStruct() {
+    CGRect result = { .origin = { .x = 10, .y = 20 }, .size = { .width = 30, .height = 40 } };
+    return result;
+}
+
 TNSComplexStruct getComplexStruct() {
     TNSComplexStruct result = { .x1 = 100, .y1 = { { .x2 = 10, .y2 = { .x3 = { 1, 2 } } }, { .x2 = 20, .y2 = { .x3 = { 3, 4 } } } }, .x4 = 123456 };
 

--- a/TestFixtures/exported-symbols.txt
+++ b/TestFixtures/exported-symbols.txt
@@ -190,6 +190,7 @@ _doubleMatrixDouble2x4
 _doubleMatrixDouble2x3
 _doubleMatrixDouble2x2
 _getNestedStruct
+_getRectStruct
 _getFloat2
 _getFloat3
 _getFloat4

--- a/TestRunner/app/tests/Marshalling/RecordTests.js
+++ b/TestRunner/app/tests/Marshalling/RecordTests.js
@@ -1,6 +1,7 @@
 describe(module.id, function () {
     afterEach(function () {
         TNSClearOutput();
+        gc();
     });
 
     it("SimpleRecord", function () {
@@ -39,6 +40,29 @@ describe(module.id, function () {
         var record = new TNSNestedStruct({a: {x: 1, y: 2}, b: {x: 3, y: 4}});
         TNSTestNativeCallbacks.recordsNestedStruct(record);
         expect(TNSGetOutput()).toBe('1 2 3 4');
+    });
+
+    it("NestedRecordSetter", function () {
+        var rect = getRectStruct();
+        rect.origin.y = 25;
+        rect.size.height = 45;
+        expect(rect.origin.x).toBe(10);
+        expect(rect.origin.y).toBe(25);
+        expect(rect.size.width).toBe(30);
+        expect(rect.size.height).toBe(45);
+    });
+
+    it("NestedRecordGCRoot", function () {
+        var size = null;
+        (() => {
+            var rect = getRectStruct();
+            size = rect.size;
+        })();
+        gc();
+        gc();
+
+        expect(size.width).toBe(30);
+        expect(size.height).toBe(40);
     });
 
     it("RecordConstructorPointer", function () {

--- a/v8ios.xcodeproj/project.pbxproj
+++ b/v8ios.xcodeproj/project.pbxproj
@@ -402,7 +402,7 @@
 		C2DDEBAC229EAC8300345BFE /* ObjectManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB83229EAC8300345BFE /* ObjectManager.h */; };
 		C2DDEBAD229EAC8300345BFE /* Caches.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB84229EAC8300345BFE /* Caches.h */; };
 		C2DDEBAE229EAC8300345BFE /* DictionaryAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB85229EAC8300345BFE /* DictionaryAdapter.h */; };
-		C2DDEBAF229EAC8300345BFE /* ObjectManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2DDEB86229EAC8300345BFE /* ObjectManager.cpp */; };
+		C2DDEBAF229EAC8300345BFE /* ObjectManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2DDEB86229EAC8300345BFE /* ObjectManager.mm */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		C2DDEBB0229EAC8300345BFE /* StringHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB87229EAC8300345BFE /* StringHasher.h */; };
 		C2DDEBB1229EAC8300345BFE /* Caches.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2DDEB88229EAC8300345BFE /* Caches.cpp */; };
 		C2DDEBB2229EAC8300345BFE /* ModuleInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB89229EAC8300345BFE /* ModuleInternal.h */; };
@@ -972,7 +972,7 @@
 		C2DDEB83229EAC8300345BFE /* ObjectManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectManager.h; sourceTree = "<group>"; };
 		C2DDEB84229EAC8300345BFE /* Caches.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Caches.h; sourceTree = "<group>"; };
 		C2DDEB85229EAC8300345BFE /* DictionaryAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DictionaryAdapter.h; sourceTree = "<group>"; };
-		C2DDEB86229EAC8300345BFE /* ObjectManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjectManager.cpp; sourceTree = "<group>"; };
+		C2DDEB86229EAC8300345BFE /* ObjectManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjectManager.mm; sourceTree = "<group>"; };
 		C2DDEB87229EAC8300345BFE /* StringHasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringHasher.h; sourceTree = "<group>"; };
 		C2DDEB88229EAC8300345BFE /* Caches.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Caches.cpp; sourceTree = "<group>"; };
 		C2DDEB89229EAC8300345BFE /* ModuleInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleInternal.h; sourceTree = "<group>"; };
@@ -1815,7 +1815,7 @@
 				C266567A22AA630F00EE15CC /* NSDataAdapter.h */,
 				C266567922AA630F00EE15CC /* NSDataAdapter.mm */,
 				C2DDEB83229EAC8300345BFE /* ObjectManager.h */,
-				C2DDEB86229EAC8300345BFE /* ObjectManager.cpp */,
+				C2DDEB86229EAC8300345BFE /* ObjectManager.mm */,
 				C266569222AFFF7E00EE15CC /* Pointer.h */,
 				C266569122AFFF7E00EE15CC /* Pointer.cpp */,
 				C266569622AFFFB000EE15CC /* Reference.h */,
@@ -2517,7 +2517,7 @@
 				C2A5F86A2359AEB600074AFA /* ExtVector.cpp in Sources */,
 				C247C33E22F828E3001D2CA2 /* v8-debugger.cc in Sources */,
 				C247C37F22F828E3001D2CA2 /* v8-css-agent-impl.cpp in Sources */,
-				C2DDEBAF229EAC8300345BFE /* ObjectManager.cpp in Sources */,
+				C2DDEBAF229EAC8300345BFE /* ObjectManager.mm in Sources */,
 				C247C35722F828E3001D2CA2 /* v8-console-agent-impl.cc in Sources */,
 				C247C35422F828E3001D2CA2 /* v8-console-message.cc in Sources */,
 				C2DDEB9C229EAC8300345BFE /* ClassBuilder.cpp in Sources */,


### PR DESCRIPTION
Replace `Persistent<Value>*` objects with smart pointers (`std::unique_ptr<>` and `std::shared_ptr<>`) for automatic memory management.