### PR TITLE
V8 lockers

### DIFF
--- a/NativeScript/NativeScript.mm
+++ b/NativeScript/NativeScript.mm
@@ -32,12 +32,15 @@ static std::shared_ptr<Runtime> runtime_;
     runtime_ = std::make_shared<Runtime>();
 
     std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
-    runtime_->Init();
+    Isolate* isolate = runtime_->CreateIsolate();
+    runtime_->Init(isolate);
     std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     printf("Runtime initialization took %llims\n", duration);
 
     if (config.IsDebug) {
+        Isolate::Scope isolate_scope(isolate);
+        HandleScope handle_scope(isolate);
         v8_inspector::JsV8InspectorClient* inspectorClient = new v8_inspector::JsV8InspectorClient(runtime_.get());
         inspectorClient->init();
         inspectorClient->registerModules();

--- a/NativeScript/runtime/ArgConverter.h
+++ b/NativeScript/runtime/ArgConverter.h
@@ -31,26 +31,26 @@ public:
 
 class ArgConverter {
 public:
-    static void Init(v8::Isolate* isolate, v8::GenericNamedPropertyGetterCallback structPropertyGetter, v8::GenericNamedPropertySetterCallback structPropertySetter);
-    static v8::Local<v8::Value> Invoke(v8::Isolate* isolate, Class klass, v8::Local<v8::Object> receiver, V8Args& args, const MethodMeta* meta, bool isMethodCallback);
-    static v8::Local<v8::Value> ConvertArgument(v8::Isolate* isolate, BaseDataWrapper* wrapper, bool skipGCRegistration = false);
-    static v8::Local<v8::Value> CreateJsWrapper(v8::Isolate* isolate, BaseDataWrapper* wrapper, v8::Local<v8::Object> receiver, bool skipGCRegistration = false);
+    static void Init(v8::Local<v8::Context> context, v8::GenericNamedPropertyGetterCallback structPropertyGetter, v8::GenericNamedPropertySetterCallback structPropertySetter);
+    static v8::Local<v8::Value> Invoke(v8::Local<v8::Context> context, Class klass, v8::Local<v8::Object> receiver, V8Args& args, const MethodMeta* meta, bool isMethodCallback);
+    static v8::Local<v8::Value> ConvertArgument(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, bool skipGCRegistration = false);
+    static v8::Local<v8::Value> CreateJsWrapper(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, v8::Local<v8::Object> receiver, bool skipGCRegistration = false);
     static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyObject(v8::Local<v8::Context> context, bool skipGCRegistration = false);
     static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyStruct(v8::Local<v8::Context> context);
     static const Meta* FindMeta(Class klass);
     static const Meta* GetMeta(std::string name);
     static const ProtocolMeta* FindProtocolMeta(Protocol* protocol);
     static void MethodCallback(ffi_cif* cif, void* retValue, void** argValues, void* userData);
-    static void SetValue(v8::Isolate* isolate, void* retValue, v8::Local<v8::Value> value, const TypeEncoding* typeEncoding);
-    static void ConstructObject(v8::Isolate* isolate, const v8::FunctionCallbackInfo<v8::Value>& info, Class klass, const InterfaceMeta* interfaceMeta = nullptr);
+    static void SetValue(v8::Local<v8::Context> context, void* retValue, v8::Local<v8::Value> value, const TypeEncoding* typeEncoding);
+    static void ConstructObject(v8::Local<v8::Context> context, const v8::FunctionCallbackInfo<v8::Value>& info, Class klass, const InterfaceMeta* interfaceMeta = nullptr);
 private:
-    static v8::Local<v8::Function> CreateEmptyInstanceFunction(v8::Isolate* isolate, v8::GenericNamedPropertyGetterCallback propertyGetter = nullptr, v8::GenericNamedPropertySetterCallback propertySetter = nullptr);
+    static v8::Local<v8::Function> CreateEmptyInstanceFunction(v8::Local<v8::Context> context, v8::GenericNamedPropertyGetterCallback propertyGetter = nullptr, v8::GenericNamedPropertySetterCallback propertySetter = nullptr);
     static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyInstance(v8::Local<v8::Context> context, v8::Persistent<v8::Function>* ctorFunc, bool skipGCRegistration = false);
     static void FindMethodOverloads(Class klass, std::string methodName, MemberType type, std::vector<const MethodMeta*>& overloads);
-    static const MethodMeta* FindInitializer(v8::Isolate* isolate, Class klass, const InterfaceMeta* interfaceMeta, const v8::FunctionCallbackInfo<v8::Value>& info, std::vector<v8::Local<v8::Value>>& args);
-    static bool CanInvoke(v8::Isolate* isolate, const TypeEncoding* typeEncoding, v8::Local<v8::Value> arg);
-    static bool CanInvoke(v8::Isolate* isolate, const MethodMeta* candidate, const v8::FunctionCallbackInfo<v8::Value>& info);
-    static std::vector<v8::Local<v8::Value>> GetInitializerArgs(v8::Isolate* isolate, v8::Local<v8::Object> obj, std::string& constructorTokens);
+    static const MethodMeta* FindInitializer(v8::Local<v8::Context> context, Class klass, const InterfaceMeta* interfaceMeta, const v8::FunctionCallbackInfo<v8::Value>& info, std::vector<v8::Local<v8::Value>>& args);
+    static bool CanInvoke(v8::Local<v8::Context> context, const TypeEncoding* typeEncoding, v8::Local<v8::Value> arg);
+    static bool CanInvoke(v8::Local<v8::Context> context, const MethodMeta* candidate, const v8::FunctionCallbackInfo<v8::Value>& info);
+    static std::vector<v8::Local<v8::Value>> GetInitializerArgs(v8::Local<v8::Object> obj, std::string& constructorTokens);
     static void IndexedPropertyGetterCallback(uint32_t index, const v8::PropertyCallbackInfo<v8::Value>& args);
     static void IndexedPropertySetterCallback(uint32_t index, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& args);
     static bool IsErrorOutParameter(const TypeEncoding* typeEncoding);

--- a/NativeScript/runtime/Caches.cpp
+++ b/NativeScript/runtime/Caches.cpp
@@ -4,6 +4,10 @@ using namespace v8;
 
 namespace tns {
 
+Caches::Caches(Isolate* isolate)
+    : isolate_(isolate) {
+}
+
 Caches::~Caches() {
     this->Prototypes.clear();
     this->ClassPrototypes.clear();
@@ -22,7 +26,7 @@ Caches::~Caches() {
 std::shared_ptr<Caches> Caches::Get(Isolate* isolate) {
     std::shared_ptr<Caches> cache = Caches::perIsolateCaches_.Get(isolate);
     if (cache == nullptr) {
-        cache = std::make_shared<Caches>();
+        cache = std::make_shared<Caches>(isolate);
         Caches::perIsolateCaches_.Insert(isolate, cache);
     }
 
@@ -31,6 +35,14 @@ std::shared_ptr<Caches> Caches::Get(Isolate* isolate) {
 
 void Caches::Remove(v8::Isolate* isolate) {
     Caches::perIsolateCaches_.Remove(isolate);
+}
+
+void Caches::SetContext(Local<Context> context) {
+    this->context_ = std::make_shared<Persistent<Context>>(this->isolate_, context);
+}
+
+Local<Context> Caches::GetContext() {
+    return this->context_->Get(this->isolate_);
 }
 
 ConcurrentMap<Isolate*, std::shared_ptr<Caches>> Caches::perIsolateCaches_;

--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -45,6 +45,7 @@ public:
         void* userData_;
     };
 
+    Caches(v8::Isolate* isolate);
     ~Caches();
 
     static ConcurrentMap<std::string, const Meta*> Metadata;
@@ -52,6 +53,9 @@ public:
 
     static std::shared_ptr<Caches> Get(v8::Isolate* isolate);
     static void Remove(v8::Isolate* isolate);
+
+    void SetContext(v8::Local<v8::Context> context);
+    v8::Local<v8::Context> GetContext();
 
     robin_hood::unordered_map<const Meta*, std::unique_ptr<v8::Persistent<v8::Value>>> Prototypes;
     robin_hood::unordered_map<std::string, std::unique_ptr<v8::Persistent<v8::Object>>> ClassPrototypes;
@@ -66,8 +70,8 @@ public:
     robin_hood::unordered_map<std::pair<void*, std::string>, std::shared_ptr<v8::Persistent<v8::Value>>, pair_hash> StructInstances;
     robin_hood::unordered_map<const void*, std::shared_ptr<v8::Persistent<v8::Object>>> PointerInstances;
 
-    std::function<v8::Local<v8::FunctionTemplate>(v8::Isolate* isolate, const BaseClassMeta*)> ObjectCtorInitializer;
-    std::function<v8::Local<v8::Function>(v8::Isolate*, StructInfo)> StructCtorInitializer;
+    std::function<v8::Local<v8::FunctionTemplate>(v8::Local<v8::Context>, const BaseClassMeta*)> ObjectCtorInitializer;
+    std::function<v8::Local<v8::Function>(v8::Local<v8::Context>, StructInfo)> StructCtorInitializer;
     robin_hood::unordered_map<std::string, double> Timers;
     robin_hood::unordered_map<const InterfaceMeta*, std::vector<const MethodMeta*>> Initializers;
 
@@ -84,6 +88,8 @@ public:
     std::unique_ptr<v8::Persistent<v8::Function>> FunctionReferenceCtorFunc = std::unique_ptr<v8::Persistent<v8::Function>>(nullptr);
 private:
     static ConcurrentMap<v8::Isolate*, std::shared_ptr<Caches>> perIsolateCaches_;
+    v8::Isolate* isolate_;
+    std::shared_ptr<v8::Persistent<v8::Context>> context_;
 };
 
 }

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -11,8 +11,8 @@ public:
     static v8::Local<v8::Function> GetExtendFunction(v8::Local<v8::Context> context, const InterfaceMeta* interfaceMeta);
     static Class GetExtendedClass(std::string baseClassName, std::string staticClassName);
 
-    static void RegisterBaseTypeScriptExtendsFunction(v8::Isolate* isolate);
-    static void RegisterNativeTypeScriptExtendsFunction(v8::Isolate* isolate);
+    static void RegisterBaseTypeScriptExtendsFunction(v8::Local<v8::Context> context);
+    static void RegisterNativeTypeScriptExtendsFunction(v8::Local<v8::Context> context);
 private:
     static unsigned long long classNameCounter_;
 
@@ -20,9 +20,9 @@ private:
     static void SuperAccessorGetterCallback(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void ExtendedClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-    static void ExposeDynamicMethods(v8::Isolate* isolate, Class extendedClass, v8::Local<v8::Value> exposedMethods, v8::Local<v8::Value> exposedProtocols, v8::Local<v8::Object> implementationObject);
-    static void ExposeDynamicMembers(v8::Isolate* isolate, Class extendedClass, v8::Local<v8::Object> implementationObject, v8::Local<v8::Object> nativeSignature);
-    static void VisitMethods(v8::Isolate* isolate, Class extendedClass, std::string methodName, const BaseClassMeta* meta, std::vector<const MethodMeta*>& methodMetas, std::vector<const ProtocolMeta*> exposedProtocols);
+    static void ExposeDynamicMethods(v8::Local<v8::Context> context, Class extendedClass, v8::Local<v8::Value> exposedMethods, v8::Local<v8::Value> exposedProtocols, v8::Local<v8::Object> implementationObject);
+    static void ExposeDynamicMembers(v8::Local<v8::Context> context, Class extendedClass, v8::Local<v8::Object> implementationObject, v8::Local<v8::Object> nativeSignature);
+    static void VisitMethods(Class extendedClass, std::string methodName, const BaseClassMeta* meta, std::vector<const MethodMeta*>& methodMetas, std::vector<const ProtocolMeta*> exposedProtocols);
     static void VisitProperties(std::string propertyName, const BaseClassMeta* meta, std::vector<const PropertyMeta*>& propertyMetas, std::vector<const ProtocolMeta*> exposedProtocols);
     static void ExposeProperties(v8::Isolate* isolate, Class extendedClass, std::vector<const PropertyMeta*> propertyMetas, v8::Local<v8::Object> implementationObject, v8::Local<v8::Value> getter, v8::Local<v8::Value> setter);
     static std::string GetTypeEncoding(const TypeEncoding* typeEncoding, int argsCount);

--- a/NativeScript/runtime/Console.h
+++ b/NativeScript/runtime/Console.h
@@ -8,17 +8,17 @@ namespace tns {
 
 class Console {
 public:
-    static void Init(v8::Isolate* isolate);
+    static void Init(v8::Local<v8::Context> context);
 private:
-    static void AttachLogFunction(v8::Isolate* isolate, v8::Local<v8::Object> console, const std::string name, v8::FunctionCallback callback = Console::LogCallback);
+    static void AttachLogFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> console, const std::string name, v8::FunctionCallback callback = Console::LogCallback);
     static void LogCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void AssertCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void DirCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void TimeCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
     static void TimeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
-    static std::string BuildStringFromArgs(v8::Isolate* isolate, const v8::FunctionCallbackInfo<v8::Value>& args, int startingIndex = 0);
-    static const v8::Local<v8::String> BuildStringFromArg(v8::Isolate* isolate, const v8::Local<v8::Value>& val);
-    static const v8::Local<v8::String> TransformJSObject(v8::Isolate* isolate, v8::Local<v8::Object> object);
+    static std::string BuildStringFromArgs(const v8::FunctionCallbackInfo<v8::Value>& args, int startingIndex = 0);
+    static const v8::Local<v8::String> BuildStringFromArg(v8::Local<v8::Context> context, const v8::Local<v8::Value>& val);
+    static const v8::Local<v8::String> TransformJSObject(v8::Local<v8::Object> object);
     static const std::string VerbosityToInspectorVerbosity(const std::string level);
 };
 

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -562,7 +562,7 @@ public:
 
     void Start(std::shared_ptr<v8::Persistent<v8::Value>> poWorker, std::function<v8::Isolate* ()> func);
     void CallOnErrorHandlers(v8::TryCatch& tc);
-    void PassUncaughtExceptionFromWorkerToMain(v8::Isolate* workerIsolate, v8::TryCatch& tc, bool async = true);
+    void PassUncaughtExceptionFromWorkerToMain(v8::Local<v8::Context> context, v8::TryCatch& tc, bool async = true);
     void PostMessage(std::string message);
     void Close();
     void Terminate();
@@ -586,7 +586,7 @@ private:
 
     void BackgroundLooper(std::function<v8::Isolate* ()> func);
     void DrainPendingTasks();
-    v8::Local<v8::Object> ConstructErrorObject(v8::Isolate* isolate, std::string message, std::string source, std::string stackTrace, int lineNumber);
+    v8::Local<v8::Object> ConstructErrorObject(v8::Local<v8::Context> context, std::string message, std::string source, std::string stackTrace, int lineNumber);
 };
 
 }

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -130,8 +130,9 @@ using namespace tns;
 - (instancetype)initWithJSObject:(Local<Object>)jsObject isolate:(Isolate*)isolate {
     if (self) {
         self->isolate_ = isolate;
-        self->object_ = ObjectManager::Register(isolate, jsObject);
         std::shared_ptr<Caches> cache = Caches::Get(isolate);
+        Local<Context> context = cache->GetContext();
+        self->object_ = ObjectManager::Register(context, jsObject);
         cache->Instances.emplace(self, self->object_);
         tns::SetValue(isolate, jsObject, new ObjCDataWrapper(self));
     }
@@ -183,7 +184,7 @@ using namespace tns;
         tns::Assert(false, isolate);
     }
 
-    id result = Interop::ToObject(self->isolate_, value);
+    id result = Interop::ToObject(context, value);
 
     return result;
 }

--- a/NativeScript/runtime/ExtVector.cpp
+++ b/NativeScript/runtime/ExtVector.cpp
@@ -30,6 +30,7 @@ Local<Value> ExtVector::NewInstance(Isolate* isolate, void* data, ffi_type* ffiT
 
 void ExtVector::IndexedPropertyGetCallback(uint32_t index, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, info.This());
     tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ExtVector, isolate);
     ExtVectorWrapper* extVectorWrapper = static_cast<ExtVectorWrapper*>(wrapper);
@@ -46,12 +47,14 @@ void ExtVector::IndexedPropertyGetCallback(uint32_t index, const PropertyCallbac
 
     void* data = extVectorWrapper->Data();
     BaseCall call((uint8_t*)data, offset);
-    Local<Value> result = Interop::GetPrimitiveReturnType(isolate, innerTypeEncoding->type, &call);
+    Local<Value> result = Interop::GetPrimitiveReturnType(context, innerTypeEncoding->type, &call);
     info.GetReturnValue().Set(result);
 }
 
 void ExtVector::IndexedPropertySetCallback(uint32_t index, Local<Value> value, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
+
     BaseDataWrapper* wrapper = tns::GetValue(isolate, info.This());
     tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ExtVector, isolate);
     ExtVectorWrapper* extVectorWrapper = static_cast<ExtVectorWrapper*>(wrapper);
@@ -67,7 +70,7 @@ void ExtVector::IndexedPropertySetCallback(uint32_t index, Local<Value> value, c
 
     void* data = extVectorWrapper->Data();
     void* dest = (uint8_t*)data + offset;
-    Interop::WriteValue(isolate, innerTypeEncoding, dest, value);
+    Interop::WriteValue(context, innerTypeEncoding, dest, value);
 }
 
 void ExtVector::RegisterToStringMethod(Isolate* isolate, Local<ObjectTemplate> prototypeTemplate) {

--- a/NativeScript/runtime/FastEnumerationAdapter.mm
+++ b/NativeScript/runtime/FastEnumerationAdapter.mm
@@ -75,7 +75,7 @@ NSUInteger FastEnumerationAdapter(Isolate* isolate, id self, NSFastEnumerationSt
             success = nextResult.As<Object>()->Get(context, tns::ToV8String(isolate, "value")).ToLocal(&value);
             tns::Assert(success && !value.IsEmpty(), isolate);
 
-            id result = Interop::ToObject(isolate, value);
+            id result = Interop::ToObject(context, value);
             *buffer++ = result;
             count++;
         }

--- a/NativeScript/runtime/FunctionReference.cpp
+++ b/NativeScript/runtime/FunctionReference.cpp
@@ -41,12 +41,13 @@ Local<v8::Function> FunctionReference::GetFunctionReferenceCtorFunc(Isolate* iso
 
 void FunctionReference::FunctionReferenceConstructorCallback(const FunctionCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
+    Local<Context> context = isolate->GetCurrentContext();
 
     tns::Assert(info.Length() == 1, isolate);
     tns::Assert(info[0]->IsFunction(), isolate);
 
     Local<v8::Function> arg = info[0].As<v8::Function>();
-    std::shared_ptr<Persistent<v8::Value>> poArg = ObjectManager::Register(isolate, arg);
+    std::shared_ptr<Persistent<v8::Value>> poArg = ObjectManager::Register(context, arg);
     FunctionReferenceWrapper* wrapper = new FunctionReferenceWrapper(poArg);
     tns::SetValue(isolate, arg, wrapper);
     info.GetReturnValue().Set(arg);

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -51,7 +51,7 @@ void LogBacktrace(int skip = 1);
 #define Log(...) NSLog(__VA_ARGS__)
 #endif
 
-v8::Local<v8::String> JsonStringifyObject(v8::Isolate* isolate, v8::Local<v8::Value> value, bool handleCircularReferences = true);
+v8::Local<v8::String> JsonStringifyObject(v8::Local<v8::Context> context, v8::Local<v8::Value> value, bool handleCircularReferences = true);
 v8::Local<v8::Function> GetSmartJSONStringifyFunction(v8::Isolate* isolate);
 
 std::string ReplaceAll(const std::string source, std::string find, std::string replacement);

--- a/NativeScript/runtime/InlineFunctions.cpp
+++ b/NativeScript/runtime/InlineFunctions.cpp
@@ -5,7 +5,7 @@ using namespace v8;
 
 namespace tns {
 
-void InlineFunctions::Init(Isolate* isolate) {
+void InlineFunctions::Init(Local<Context> context) {
 
     std::string inlineFunctionsSource =
         "Object.assign(global, {"
@@ -111,7 +111,7 @@ void InlineFunctions::Init(Isolate* isolate) {
         "});"
     ;
 
-    Local<Context> context = isolate->GetCurrentContext();
+    Isolate* isolate = context->GetIsolate();
 
     Local<Script> script;
     if (!Script::Compile(context, tns::ToV8String(isolate, inlineFunctionsSource)).ToLocal(&script)) {

--- a/NativeScript/runtime/InlineFunctions.h
+++ b/NativeScript/runtime/InlineFunctions.h
@@ -7,7 +7,7 @@ namespace tns {
 
 class InlineFunctions {
 public:
-    static void Init(v8::Isolate* isolate);
+    static void Init(v8::Local<v8::Context> context);
     static bool IsGlobalFunction(std::string name);
 };
 

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -14,37 +14,37 @@ typedef void (*FFIMethodCallback)(ffi_cif* cif, void* retValue, void** argValues
 
 class Interop {
 public:
-    static void RegisterInteropTypes(v8::Isolate* isolate);
+    static void RegisterInteropTypes(v8::Local<v8::Context> context);
     static CFTypeRef CreateBlock(const uint8_t initialParamIndex, const uint8_t argsCount, const TypeEncoding* typeEncoding, FFIMethodCallback callback, void* userData);
     static IMP CreateMethod(const uint8_t initialParamIndex, const uint8_t argsCount, const TypeEncoding* typeEncoding, FFIMethodCallback callback, void* userData);
-    static id CallInitializer(v8::Isolate* isolate, const MethodMeta* methodMeta, id target, Class clazz, V8Args& args);
-    static v8::Local<v8::Value> CallFunction(v8::Isolate* isolate, const MethodMeta* meta, id target, Class clazz, V8Args& args, bool callSuper);
-    static v8::Local<v8::Value> CallFunction(v8::Isolate* isolate, void* functionPointer, const TypeEncoding* typeEncoding, V8Args& args);
-    static v8::Local<v8::Value> GetResult(v8::Isolate* isolate, const TypeEncoding* typeEncoding, BaseCall* call, bool marshalToPrimitive, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct = nullptr, bool isStructMember = false);
-    static void SetStructPropertyValue(v8::Isolate* isolate, StructWrapper* wrapper, StructField field, v8::Local<v8::Value> value);
-    static void InitializeStruct(v8::Isolate* isolate, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer);
-    static void WriteValue(v8::Isolate* isolate, const TypeEncoding* typeEncoding, void* dest, v8::Local<v8::Value> arg);
-    static id ToObject(v8::Isolate* isolate, v8::Local<v8::Value> arg);
-    static v8::Local<v8::Value> GetPrimitiveReturnType(v8::Isolate* isolate, BinaryTypeEncodingType type, BaseCall* call);
+    static id CallInitializer(v8::Local<v8::Context> context, const MethodMeta* methodMeta, id target, Class clazz, V8Args& args);
+    static v8::Local<v8::Value> CallFunction(v8::Local<v8::Context> context, const MethodMeta* meta, id target, Class clazz, V8Args& args, bool callSuper);
+    static v8::Local<v8::Value> CallFunction(v8::Local<v8::Context> context, void* functionPointer, const TypeEncoding* typeEncoding, V8Args& args);
+    static v8::Local<v8::Value> GetResult(v8::Local<v8::Context> context, const TypeEncoding* typeEncoding, BaseCall* call, bool marshalToPrimitive, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct = nullptr, bool isStructMember = false);
+    static void SetStructPropertyValue(v8::Local<v8::Context> context, StructWrapper* wrapper, StructField field, v8::Local<v8::Value> value);
+    static void InitializeStruct(v8::Local<v8::Context> context, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer);
+    static void WriteValue(v8::Local<v8::Context> context, const TypeEncoding* typeEncoding, void* dest, v8::Local<v8::Value> arg);
+    static id ToObject(v8::Local<v8::Context> context, v8::Local<v8::Value> arg);
+    static v8::Local<v8::Value> GetPrimitiveReturnType(v8::Local<v8::Context> context, BinaryTypeEncodingType type, BaseCall* call);
 private:
     template <typename T>
     static void SetStructValue(v8::Local<v8::Value> value, void* destBuffer, ptrdiff_t position);
-    static void InitializeStruct(v8::Isolate* isolate, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer, ptrdiff_t& position);
-    static void RegisterInteropType(v8::Isolate* isolate, v8::Local<v8::Object> types, std::string name, PrimitiveDataWrapper* wrapper);
-    static void RegisterBufferFromDataFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void RegisterHandleOfFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void RegisterAllocFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void RegisterFreeFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void RegisterAdoptFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void RegisterSizeOfFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static void SetFFIParams(v8::Isolate* isolate, const TypeEncoding* typeEncoding, FFICall* call, const int argsCount, const int initialParameterIndex, V8Args& args);
-    static v8::Local<v8::Array> ToArray(v8::Isolate* isolate, v8::Local<v8::Object> object);
-    static v8::Local<v8::Value> StructToValue(v8::Isolate* isolate, void* result, StructInfo structInfo, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct);
+    static void InitializeStruct(v8::Local<v8::Context> context, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer, ptrdiff_t& position);
+    static void RegisterInteropType(v8::Local<v8::Context> context, v8::Local<v8::Object> types, std::string name, PrimitiveDataWrapper* wrapper);
+    static void RegisterBufferFromDataFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterHandleOfFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterAllocFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterFreeFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterAdoptFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterSizeOfFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void SetFFIParams(v8::Local<v8::Context> context, const TypeEncoding* typeEncoding, FFICall* call, const int argsCount, const int initialParameterIndex, V8Args& args);
+    static v8::Local<v8::Array> ToArray(v8::Local<v8::Object> object);
+    static v8::Local<v8::Value> StructToValue(v8::Local<v8::Context> context, void* result, StructInfo structInfo, std::shared_ptr<v8::Persistent<v8::Value>> parentStruct);
     static const TypeEncoding* CreateEncoding(BinaryTypeEncodingType type);
-    static v8::Local<v8::Value> HandleOf(v8::Isolate* isolate, v8::Local<v8::Value> value);
-    static v8::Local<v8::Value> CallFunctionInternal(v8::Isolate* isolate, bool isPrimitiveFunction, void* functionPointer, const TypeEncoding* typeEncoding, V8Args& args, id target, Class clazz, SEL selector, bool callSuper, MetaType metaType, bool provideErrorOurParameter = false);
+    static v8::Local<v8::Value> HandleOf(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
+    static v8::Local<v8::Value> CallFunctionInternal(v8::Local<v8::Context> context, bool isPrimitiveFunction, void* functionPointer, const TypeEncoding* typeEncoding, V8Args& args, id target, Class clazz, SEL selector, bool callSuper, MetaType metaType, bool provideErrorOurParameter = false);
     static bool IsNumbericType(BinaryTypeEncodingType type);
-    static v8::Local<v8::Object> GetInteropType(v8::Isolate* isolate, BinaryTypeEncodingType type);
+    static v8::Local<v8::Object> GetInteropType(v8::Local<v8::Context> context, BinaryTypeEncodingType type);
 
     template <typename T>
     static inline void SetValue(void* dest, T value) {

--- a/NativeScript/runtime/InteropTypes.mm
+++ b/NativeScript/runtime/InteropTypes.mm
@@ -13,45 +13,45 @@ using namespace v8;
 
 namespace tns {
 
-void Interop::RegisterInteropTypes(Isolate* isolate) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterInteropTypes(Local<Context> context) {
+    Isolate* isolate = context->GetIsolate();
     Local<Object> global = context->Global();
 
     Local<Object> interop = Object::New(isolate);
     Local<Object> types = Object::New(isolate);
 
-    Reference::Register(isolate, interop);
-    Pointer::Register(isolate, interop);
+    Reference::Register(context, interop);
+    Pointer::Register(context, interop);
     FunctionReference::Register(isolate, interop);
-    RegisterBufferFromDataFunction(isolate, interop);
-    RegisterHandleOfFunction(isolate, interop);
-    RegisterAllocFunction(isolate, interop);
-    RegisterFreeFunction(isolate, interop);
-    RegisterAdoptFunction(isolate, interop);
-    RegisterSizeOfFunction(isolate, interop);
+    RegisterBufferFromDataFunction(context, interop);
+    RegisterHandleOfFunction(context, interop);
+    RegisterAllocFunction(context, interop);
+    RegisterFreeFunction(context, interop);
+    RegisterAdoptFunction(context, interop);
+    RegisterSizeOfFunction(context, interop);
 
-    RegisterInteropType(isolate, types, "noop", new PrimitiveDataWrapper(ffi_type_pointer.size, CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
-    RegisterInteropType(isolate, types, "void", new PrimitiveDataWrapper(0, CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
-    RegisterInteropType(isolate, types, "bool", new PrimitiveDataWrapper(sizeof(bool), CreateEncoding(BinaryTypeEncodingType::BoolEncoding)));
-    RegisterInteropType(isolate, types, "uint8", new PrimitiveDataWrapper(ffi_type_uint8.size, CreateEncoding(BinaryTypeEncodingType::UCharEncoding)));
-    RegisterInteropType(isolate, types, "int8", new PrimitiveDataWrapper(ffi_type_sint8.size, CreateEncoding(BinaryTypeEncodingType::CharEncoding)));
-    RegisterInteropType(isolate, types, "uint16", new PrimitiveDataWrapper(ffi_type_uint16.size, CreateEncoding(BinaryTypeEncodingType::UShortEncoding)));
-    RegisterInteropType(isolate, types, "int16", new PrimitiveDataWrapper(ffi_type_sint16.size, CreateEncoding(BinaryTypeEncodingType::ShortEncoding)));
-    RegisterInteropType(isolate, types, "uint32", new PrimitiveDataWrapper(ffi_type_uint32.size, CreateEncoding(BinaryTypeEncodingType::UIntEncoding)));
-    RegisterInteropType(isolate, types, "int32", new PrimitiveDataWrapper(ffi_type_sint32.size, CreateEncoding(BinaryTypeEncodingType::IntEncoding)));
-    RegisterInteropType(isolate, types, "uint64", new PrimitiveDataWrapper(ffi_type_uint64.size, CreateEncoding(BinaryTypeEncodingType::ULongEncoding)));
-    RegisterInteropType(isolate, types, "int64", new PrimitiveDataWrapper(ffi_type_sint64.size, CreateEncoding(BinaryTypeEncodingType::LongEncoding)));
-    RegisterInteropType(isolate, types, "ulong", new PrimitiveDataWrapper(ffi_type_ulong.size, CreateEncoding(BinaryTypeEncodingType::ULongLongEncoding)));
-    RegisterInteropType(isolate, types, "slong", new PrimitiveDataWrapper(ffi_type_slong.size, CreateEncoding(BinaryTypeEncodingType::LongLongEncoding)));
-    RegisterInteropType(isolate, types, "float", new PrimitiveDataWrapper(ffi_type_float.size, CreateEncoding(BinaryTypeEncodingType::FloatEncoding)));
-    RegisterInteropType(isolate, types, "double", new PrimitiveDataWrapper(ffi_type_double.size, CreateEncoding(BinaryTypeEncodingType::DoubleEncoding)));
+    RegisterInteropType(context, types, "noop", new PrimitiveDataWrapper(ffi_type_pointer.size, CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
+    RegisterInteropType(context, types, "void", new PrimitiveDataWrapper(0, CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
+    RegisterInteropType(context, types, "bool", new PrimitiveDataWrapper(sizeof(bool), CreateEncoding(BinaryTypeEncodingType::BoolEncoding)));
+    RegisterInteropType(context, types, "uint8", new PrimitiveDataWrapper(ffi_type_uint8.size, CreateEncoding(BinaryTypeEncodingType::UCharEncoding)));
+    RegisterInteropType(context, types, "int8", new PrimitiveDataWrapper(ffi_type_sint8.size, CreateEncoding(BinaryTypeEncodingType::CharEncoding)));
+    RegisterInteropType(context, types, "uint16", new PrimitiveDataWrapper(ffi_type_uint16.size, CreateEncoding(BinaryTypeEncodingType::UShortEncoding)));
+    RegisterInteropType(context, types, "int16", new PrimitiveDataWrapper(ffi_type_sint16.size, CreateEncoding(BinaryTypeEncodingType::ShortEncoding)));
+    RegisterInteropType(context, types, "uint32", new PrimitiveDataWrapper(ffi_type_uint32.size, CreateEncoding(BinaryTypeEncodingType::UIntEncoding)));
+    RegisterInteropType(context, types, "int32", new PrimitiveDataWrapper(ffi_type_sint32.size, CreateEncoding(BinaryTypeEncodingType::IntEncoding)));
+    RegisterInteropType(context, types, "uint64", new PrimitiveDataWrapper(ffi_type_uint64.size, CreateEncoding(BinaryTypeEncodingType::ULongEncoding)));
+    RegisterInteropType(context, types, "int64", new PrimitiveDataWrapper(ffi_type_sint64.size, CreateEncoding(BinaryTypeEncodingType::LongEncoding)));
+    RegisterInteropType(context, types, "ulong", new PrimitiveDataWrapper(ffi_type_ulong.size, CreateEncoding(BinaryTypeEncodingType::ULongLongEncoding)));
+    RegisterInteropType(context, types, "slong", new PrimitiveDataWrapper(ffi_type_slong.size, CreateEncoding(BinaryTypeEncodingType::LongLongEncoding)));
+    RegisterInteropType(context, types, "float", new PrimitiveDataWrapper(ffi_type_float.size, CreateEncoding(BinaryTypeEncodingType::FloatEncoding)));
+    RegisterInteropType(context, types, "double", new PrimitiveDataWrapper(ffi_type_double.size, CreateEncoding(BinaryTypeEncodingType::DoubleEncoding)));
 
-    RegisterInteropType(isolate, types, "id", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::IdEncoding)));
-//    RegisterInteropType(isolate, types, "UTF8CString", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
-    RegisterInteropType(isolate, types, "unichar", new PrimitiveDataWrapper(ffi_type_ushort.size, CreateEncoding(BinaryTypeEncodingType::UnicharEncoding)));
-    RegisterInteropType(isolate, types, "protocol", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ProtocolEncoding)));
-    RegisterInteropType(isolate, types, "class", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ClassEncoding)));
-    RegisterInteropType(isolate, types, "selector", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::SelectorEncoding)));
+    RegisterInteropType(context, types, "id", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::IdEncoding)));
+//    RegisterInteropType(context, types, "UTF8CString", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
+    RegisterInteropType(context, types, "unichar", new PrimitiveDataWrapper(ffi_type_ushort.size, CreateEncoding(BinaryTypeEncodingType::UnicharEncoding)));
+    RegisterInteropType(context, types, "protocol", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ProtocolEncoding)));
+    RegisterInteropType(context, types, "class", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ClassEncoding)));
+    RegisterInteropType(context, types, "selector", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::SelectorEncoding)));
 
     bool success = interop->Set(context, tns::ToV8String(isolate, "types"), types).FromMaybe(false);
     tns::Assert(success, isolate);
@@ -60,7 +60,8 @@ void Interop::RegisterInteropTypes(Isolate* isolate) {
     tns::Assert(success, isolate);
 }
 
-Local<Object> Interop::GetInteropType(Isolate* isolate, BinaryTypeEncodingType type) {
+Local<Object> Interop::GetInteropType(Local<Context> context, BinaryTypeEncodingType type) {
+    Isolate* isolate = context->GetIsolate();
     std::shared_ptr<Caches> cache = Caches::Get(isolate);
     auto it = cache->PrimitiveInteropTypes.find(type);
     if (it != cache->PrimitiveInteropTypes.end()) {
@@ -70,8 +71,8 @@ Local<Object> Interop::GetInteropType(Isolate* isolate, BinaryTypeEncodingType t
     return Local<Object>();
 }
 
-void Interop::RegisterInteropType(Isolate* isolate, Local<Object> types, std::string name, PrimitiveDataWrapper* wrapper) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterInteropType(Local<Context> context, Local<Object> types, std::string name, PrimitiveDataWrapper* wrapper) {
+    Isolate* isolate = context->GetIsolate();
     Local<FunctionTemplate> ctorFuncTemplate = FunctionTemplate::New(isolate, nullptr);
     ctorFuncTemplate->SetClassName(tns::ToV8String(isolate, name));
     ctorFuncTemplate->InstanceTemplate()->SetInternalFieldCount(1);
@@ -100,8 +101,7 @@ void Interop::RegisterInteropType(Isolate* isolate, Local<Object> types, std::st
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterBufferFromDataFunction(v8::Isolate* isolate, v8::Local<v8::Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterBufferFromDataFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
@@ -123,22 +123,24 @@ void Interop::RegisterBufferFromDataFunction(v8::Isolate* isolate, v8::Local<v8:
         Local<ArrayBuffer> result = ArrayBuffer::New(isolate, std::move(backingStore));
         info.GetReturnValue().Set(result);
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "bufferFromData"), func).FromMaybe(false);
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterHandleOfFunction(Isolate* isolate, Local<Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterHandleOfFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
+        Local<Context> context = isolate->GetCurrentContext();
         tns::Assert(info.Length() == 1, isolate);
         try {
             Local<Value> arg = info[0];
 
-            Local<Value> result = Interop::HandleOf(isolate, arg);
+            Local<Value> result = Interop::HandleOf(context, arg);
             if (result.IsEmpty()) {
                 throw NativeScriptException("Unknown type");
             }
@@ -148,14 +150,15 @@ void Interop::RegisterHandleOfFunction(Isolate* isolate, Local<Object> interop) 
             ex.ReThrowToV8(isolate);
         }
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "handleof"), func).FromMaybe(false);
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterAllocFunction(Isolate* isolate, Local<Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterAllocFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
@@ -171,19 +174,20 @@ void Interop::RegisterAllocFunction(Isolate* isolate, Local<Object> interop) {
 
         void* data = calloc(1, size);
 
-        Local<Value> pointerInstance = Pointer::NewInstance(isolate, data);
+        Local<Value> pointerInstance = Pointer::NewInstance(context, data);
         PointerWrapper* wrapper = static_cast<PointerWrapper*>(pointerInstance.As<Object>()->GetInternalField(0).As<External>()->Value());
         wrapper->SetAdopted(true);
         info.GetReturnValue().Set(pointerInstance);
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "alloc"), func).FromMaybe(false);
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterFreeFunction(Isolate* isolate, Local<Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterFreeFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
@@ -205,14 +209,15 @@ void Interop::RegisterFreeFunction(Isolate* isolate, Local<Object> interop) {
 
         info.GetReturnValue().Set(v8::Undefined(isolate));
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "free"), func).FromMaybe(false);
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterAdoptFunction(Isolate* isolate, Local<Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterAdoptFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
@@ -227,14 +232,15 @@ void Interop::RegisterAdoptFunction(Isolate* isolate, Local<Object> interop) {
 
         info.GetReturnValue().Set(arg);
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "adopt"), func).FromMaybe(false);
     tns::Assert(success, isolate);
 }
 
-void Interop::RegisterSizeOfFunction(Isolate* isolate, Local<Object> interop) {
-    Local<Context> context = isolate->GetCurrentContext();
+void Interop::RegisterSizeOfFunction(Local<Context> context, Local<Object> interop) {
     Local<v8::Function> func;
     bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
@@ -294,6 +300,8 @@ void Interop::RegisterSizeOfFunction(Isolate* isolate, Local<Object> interop) {
             ex.ReThrowToV8(isolate);
         }
     }).ToLocal(&func);
+
+    Isolate* isolate = context->GetIsolate();
     tns::Assert(success, isolate);
 
     success = interop->Set(context, tns::ToV8String(isolate, "sizeof"), func).FromMaybe(false);
@@ -307,16 +315,17 @@ const TypeEncoding* Interop::CreateEncoding(BinaryTypeEncodingType type) {
     return typeEncoding;
 }
 
-Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
+Local<Value> Interop::HandleOf(Local<Context> context, Local<Value> value) {
+    Isolate* isolate = context->GetIsolate();
     if (!value->IsNullOrUndefined()) {
         if (value->IsArrayBuffer()) {
             Local<ArrayBuffer> buffer = value.As<ArrayBuffer>();
             std::shared_ptr<BackingStore> backingStore = buffer->GetBackingStore();
-            return Pointer::NewInstance(isolate, backingStore->Data());
+            return Pointer::NewInstance(context, backingStore->Data());
         } else if (value->IsArrayBufferView()) {
             Local<ArrayBufferView> bufferView = value.As<ArrayBufferView>();
             std::shared_ptr<BackingStore> backingStore = bufferView->Buffer()->GetBackingStore();
-            return Pointer::NewInstance(isolate, backingStore->Data());
+            return Pointer::NewInstance(context, backingStore->Data());
         } else if (value->IsObject()) {
             Local<Object> obj = value.As<Object>();
             if (BaseDataWrapper* wrapper = tns::GetValue(isolate, obj)) {
@@ -324,7 +333,7 @@ Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
                     case WrapperType::Primitive: {
                         PrimitiveDataWrapper* pdw = static_cast<PrimitiveDataWrapper*>(wrapper);
                         void* handle = pdw;
-                        return Pointer::NewInstance(isolate, handle);
+                        return Pointer::NewInstance(context, handle);
                     }
                     case WrapperType::ObjCClass: {
                         ObjCClassWrapper* cw = static_cast<ObjCClassWrapper*>(wrapper);
@@ -332,7 +341,7 @@ Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
                             CFTypeRef ref = CFBridgingRetain(cw->Klass());
                             void* handle = const_cast<void*>(ref);
                             CFRelease(ref);
-                            return Pointer::NewInstance(isolate, handle);
+                            return Pointer::NewInstance(context, handle);
                         }
                         break;
                     }
@@ -341,7 +350,7 @@ Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
                         CFTypeRef ref = CFBridgingRetain(pw->Proto());
                         void* handle = const_cast<void*>(ref);
                         CFRelease(ref);
-                        return Pointer::NewInstance(isolate, handle);
+                        return Pointer::NewInstance(context, handle);
                     }
                     case WrapperType::ObjCObject: {
                         ObjCDataWrapper* w = static_cast<ObjCDataWrapper*>(wrapper);
@@ -350,24 +359,24 @@ Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
                             CFTypeRef ref = CFBridgingRetain(target);
                             void* handle = const_cast<void*>(ref);
                             CFRelease(ref);
-                            return Pointer::NewInstance(isolate, handle);
+                            return Pointer::NewInstance(context, handle);
                         }
                         break;
                     }
                     case WrapperType::Struct: {
                         StructWrapper* w = static_cast<StructWrapper*>(wrapper);
-                        return Pointer::NewInstance(isolate, w->Data());
+                        return Pointer::NewInstance(context, w->Data());
                     }
                     case WrapperType::Reference: {
                         ReferenceWrapper* w = static_cast<ReferenceWrapper*>(wrapper);
                         if (w->Value() != nullptr) {
                             Local<Value> wrappedValue = w->Value()->Get(isolate);
                             if (tns::GetValue(isolate, wrappedValue) == nullptr) {
-                                return Pointer::NewInstance(isolate, w->Value());
+                                return Pointer::NewInstance(context, w->Value());
                             }
-                            return HandleOf(isolate, wrappedValue);
+                            return HandleOf(context, wrappedValue);
                         } else if (w->Data() != nullptr) {
-                            return Pointer::NewInstance(isolate, w->Data());
+                            return Pointer::NewInstance(context, w->Data());
                         }
                         break;
                     }
@@ -378,18 +387,18 @@ Local<Value> Interop::HandleOf(Isolate* isolate, Local<Value> value) {
                         FunctionWrapper* w = static_cast<FunctionWrapper*>(wrapper);
                         const FunctionMeta* meta = w->Meta();
                         void* handle = SymbolLoader::instance().loadFunctionSymbol(meta->topLevelModule(), meta->name());
-                        return Pointer::NewInstance(isolate, handle);
+                        return Pointer::NewInstance(context, handle);
                     }
                     case WrapperType::FunctionReference: {
                         FunctionReferenceWrapper* w = static_cast<FunctionReferenceWrapper*>(wrapper);
                         if (w->Data() != nullptr) {
-                            return Pointer::NewInstance(isolate, w->Data());
+                            return Pointer::NewInstance(context, w->Data());
                         }
                         break;
                     }
                     case WrapperType::Block: {
                         BlockWrapper* blockWrapper = static_cast<BlockWrapper*>(wrapper);
-                        return Pointer::NewInstance(isolate, blockWrapper->Block());
+                        return Pointer::NewInstance(context, blockWrapper->Block());
                     }
                     default:
                         break;

--- a/NativeScript/runtime/MetadataBuilder.h
+++ b/NativeScript/runtime/MetadataBuilder.h
@@ -12,14 +12,14 @@ namespace tns {
 
 class MetadataBuilder {
 public:
-    static void RegisterConstantsOnGlobalObject(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> global, bool isWorkerThread);
-    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplate(v8::Isolate* isolate, const BaseClassMeta* meta);
-    static v8::Local<v8::Function> GetOrCreateStructCtorFunction(v8::Isolate* isolate, StructInfo structInfo);
+    static void RegisterConstantsOnGlobalObject(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate, bool isWorkerThread);
+    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplate(v8::Local<v8::Context> context, const BaseClassMeta* meta);
+    static v8::Local<v8::Function> GetOrCreateStructCtorFunction(v8::Local<v8::Context> context, StructInfo structInfo);
     static void StructPropertyGetterCallback(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void StructPropertySetterCallback(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
-    static void CreateToStringFunction(v8::Isolate* isolate);
+    static void CreateToStringFunction(v8::Local<v8::Context> context);
 private:
-    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplateInternal(v8::Isolate* isolate, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& instanceMembers, robin_hood::unordered_map<std::string, uint8_t>& staticMembers);
+    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplateInternal(v8::Local<v8::Context> context, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& instanceMembers, robin_hood::unordered_map<std::string, uint8_t>& staticMembers);
     static void GlobalPropertyGetter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void AllocCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -32,16 +32,16 @@ private:
     static void StructConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void StructEqualsCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void ToStringFunctionCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-    static std::pair<ffi_type*, void*> GetStructData(v8::Isolate* isolate, v8::Local<v8::Object> initializer, StructInfo structInfo);
+    static std::pair<ffi_type*, void*> GetStructData(v8::Local<v8::Context> context, v8::Local<v8::Object> initializer, StructInfo structInfo);
 
-    static v8::Local<v8::Value> InvokeMethod(v8::Isolate* isolate, const MethodMeta* meta, v8::Local<v8::Object> receiver, V8Args& args, std::string containingClass, bool isMethodCallback);
-    static void RegisterAllocMethod(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc, const InterfaceMeta* interfaceMeta);
-    static void RegisterInstanceMethods(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& names);
-    static void RegisterInstanceProperties(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
-    static void RegisterInstanceProtocols(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
-    static void RegisterStaticMethods(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& names);
-    static void RegisterStaticProperties(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
-    static void RegisterStaticProtocols(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static v8::Local<v8::Value> InvokeMethod(v8::Local<v8::Context> context, const MethodMeta* meta, v8::Local<v8::Object> receiver, V8Args& args, std::string containingClass, bool isMethodCallback);
+    static void RegisterAllocMethod(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const InterfaceMeta* interfaceMeta);
+    static void RegisterInstanceMethods(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterInstanceProperties(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterInstanceProtocols(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterStaticMethods(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterStaticProperties(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterStaticProtocols(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void DefineFunctionLengthProperty(v8::Local<v8::Context> context, const TypeEncodingsList<ArrayCount>* encodings, v8::Local<v8::Function> func);
 
     struct GlobalHandlerContext {

--- a/NativeScript/runtime/ModuleInternal.h
+++ b/NativeScript/runtime/ModuleInternal.h
@@ -8,7 +8,7 @@ namespace tns {
 
 class ModuleInternal {
 public:
-    ModuleInternal(v8::Isolate* isolate);
+    ModuleInternal(v8::Local<v8::Context> context);
     bool RunModule(v8::Isolate* isolate, std::string path);
 private:
     static void RequireCallback(const v8::FunctionCallbackInfo<v8::Value>& info);

--- a/NativeScript/runtime/ModuleInternal.mm
+++ b/NativeScript/runtime/ModuleInternal.mm
@@ -4,13 +4,14 @@
 #include "ModuleInternal.h"
 #include "NativeScriptException.h"
 #include "RuntimeConfig.h"
+#include "Caches.h"
 #include "Helpers.h"
 
 using namespace v8;
 
 namespace tns {
 
-ModuleInternal::ModuleInternal(Isolate* isolate) {
+ModuleInternal::ModuleInternal(Local<Context> context) {
     std::string requireFactoryScript =
         "(function() { "
         "    function require_factory(requireInternal, dirName) { "
@@ -21,7 +22,7 @@ ModuleInternal::ModuleInternal(Isolate* isolate) {
         "    return require_factory; "
         "})()";
 
-    Local<Context> context = isolate->GetCurrentContext();
+    Isolate* isolate = context->GetIsolate();
     Local<Object> global = context->Global();
     Local<Script> script;
     TryCatch tc(isolate);
@@ -49,7 +50,8 @@ ModuleInternal::ModuleInternal(Isolate* isolate) {
 }
 
 bool ModuleInternal::RunModule(Isolate* isolate, std::string path) {
-    Local<Context> context = isolate->GetCurrentContext();
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
+    Local<Context> context = cache->GetContext();
     Local<Object> globalObject = context->Global();
     Local<Value> requireObj;
     bool success = globalObject->Get(context, ToV8String(isolate, "require")).ToLocal(&requireObj);

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -15,8 +15,9 @@ using namespace v8;
     if (self) {
         tns::Assert(jsObject->IsArrayBuffer() || jsObject->IsArrayBufferView(), isolate);
         self->isolate_ = isolate;
-        self->object_ = ObjectManager::Register(isolate, jsObject);
         std::shared_ptr<Caches> cache = Caches::Get(isolate);
+        Local<Context> context = cache->GetContext();
+        self->object_ = ObjectManager::Register(context, jsObject);
         cache->Instances.emplace(self, self->object_);
         tns::SetValue(isolate, jsObject, new ObjCDataWrapper(self));
     }

--- a/NativeScript/runtime/NativeScriptException.mm
+++ b/NativeScript/runtime/NativeScriptException.mm
@@ -1,6 +1,7 @@
 #include "NativeScriptException.h"
 #include "Runtime.h"
 #include "Helpers.h"
+#include "Caches.h"
 #include <sstream>
 
 using namespace v8;
@@ -89,7 +90,8 @@ void NativeScriptException::ReThrowToV8(Isolate* isolate) {
 }
 
 std::string NativeScriptException::GetErrorMessage(Isolate* isolate, Local<Value>& error, const std::string& prependMessage) {
-    Local<Context> context = isolate->GetEnteredOrMicrotaskContext();
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
+    Local<Context> context = cache->GetContext();
 
     // get whole error message from previous stack
     std::stringstream ss;

--- a/NativeScript/runtime/ObjectManager.h
+++ b/NativeScript/runtime/ObjectManager.h
@@ -17,7 +17,7 @@ struct ObjectWeakCallbackState {
 class ObjectManager {
 public:
     static void Init(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate);
-    static std::shared_ptr<v8::Persistent<v8::Value>> Register(v8::Isolate* isolate, const v8::Local<v8::Value> obj);
+    static std::shared_ptr<v8::Persistent<v8::Value>> Register(v8::Local<v8::Context> context, const v8::Local<v8::Value> obj);
     static void FinalizerCallback(const v8::WeakCallbackInfo<ObjectWeakCallbackState>& data);
 private:
     static bool DisposeValue(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/NativeScript/runtime/ObjectManager.mm
+++ b/NativeScript/runtime/ObjectManager.mm
@@ -19,7 +19,8 @@ void ObjectManager::Init(Isolate* isolate, Local<ObjectTemplate> globalTemplate)
     globalTemplate->Set(tns::ToV8String(isolate, "__releaseNativeCounterpart"), FunctionTemplate::New(isolate, ReleaseNativeCounterpartCallback));
 }
 
-std::shared_ptr<Persistent<Value>> ObjectManager::Register(Isolate* isolate, const Local<Value> obj) {
+std::shared_ptr<Persistent<Value>> ObjectManager::Register(Local<Context> context, const Local<Value> obj) {
+    Isolate* isolate = context->GetIsolate();
     std::shared_ptr<Persistent<Value>> objectHandle = std::make_shared<Persistent<Value>>(isolate, obj);
     ObjectWeakCallbackState* state = new ObjectWeakCallbackState(objectHandle);
     objectHandle->SetWeak(state, FinalizerCallback, WeakCallbackType::kFinalizer);

--- a/NativeScript/runtime/Pointer.h
+++ b/NativeScript/runtime/Pointer.h
@@ -8,17 +8,17 @@ namespace tns {
 
 class Pointer {
 public:
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static v8::Local<v8::Value> NewInstance(v8::Isolate* isolate, void* handle);
+    static void Register(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static v8::Local<v8::Value> NewInstance(v8::Local<v8::Context> context, void* handle);
 private:
-    static v8::Local<v8::Function> GetPointerCtorFunc(v8::Isolate* isolate);
+    static v8::Local<v8::Function> GetPointerCtorFunc(v8::Local<v8::Context> context);
     static void PointerConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-    static void RegisterAddMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static void RegisterSubtractMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static void RegisterToStringMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static void RegisterToHexStringMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static void RegisterToDecimalStringMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static void RegisterToNumberMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
+    static void RegisterAddMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static void RegisterSubtractMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static void RegisterToStringMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static void RegisterToHexStringMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static void RegisterToDecimalStringMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static void RegisterToNumberMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
 };
 
 }

--- a/NativeScript/runtime/PromiseProxy.cpp
+++ b/NativeScript/runtime/PromiseProxy.cpp
@@ -1,0 +1,57 @@
+#include "PromiseProxy.h"
+#include "Helpers.h"
+
+using namespace v8;
+
+namespace tns {
+
+void PromiseProxy::Init(v8::Local<v8::Context> context) {
+    std::string source = R"(
+        // Ensure that Promise callbacks are executed on the
+        // same thread on which they were created
+        (() => {
+            global.Promise = new Proxy(global.Promise, {
+                construct: function(target, args) {
+                    let origFunc = args[0];
+                    let runloop = CFRunLoopGetCurrent();
+
+                    let promise = new target(function(resolve, reject) {
+                        origFunc(value => {
+                            CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, resolve.bind(this, value));
+                            CFRunLoopWakeUp(runloop);
+                        }, reason => {
+                            CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, reject.bind(this, reason));
+                            CFRunLoopWakeUp(runloop);
+                        });
+                    });
+
+                    return new Proxy(promise, {
+                        get: function(target, name) {
+                            let orig = target[name];
+                            if (name === "then") {
+                                return orig.bind(target);
+                            }
+                            return function(x) {
+                                CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, orig.bind(target, x));
+                                CFRunLoopWakeUp(runloop);
+                                return target;
+                            };
+                        }
+                    });
+                }
+            });
+        })();
+    )";
+
+    Isolate* isolate = context->GetIsolate();
+
+    Local<Script> script;
+    bool success = Script::Compile(context, tns::ToV8String(isolate, source)).ToLocal(&script);
+    tns::Assert(success && !script.IsEmpty(), isolate);
+
+    Local<Value> result;
+    success = script->Run(context).ToLocal(&result);
+    tns::Assert(success, isolate);
+}
+
+}

--- a/NativeScript/runtime/PromiseProxy.h
+++ b/NativeScript/runtime/PromiseProxy.h
@@ -1,0 +1,15 @@
+#ifndef PromiseProxy_h
+#define PromiseProxy_h
+
+#include "Common.h"
+
+namespace tns {
+
+class PromiseProxy {
+public:
+    static void Init(v8::Local<v8::Context> context);
+};
+
+}
+
+#endif /* PromiseProxy_h */

--- a/NativeScript/runtime/Reference.h
+++ b/NativeScript/runtime/Reference.h
@@ -8,10 +8,10 @@ namespace tns {
 
 class Reference {
 public:
-    static void Register(v8::Isolate* isolate, v8::Local<v8::Object> interop);
-    static v8::Local<v8::Value> FromPointer(v8::Isolate* isolate, v8::Local<v8::Value> type, void* handle);
-    static v8::Local<v8::Function> GetInteropReferenceCtorFunc(v8::Isolate* isolate);
-    static void* GetWrappedPointer(v8::Isolate* isolate, v8::Local<v8::Value> reference, const TypeEncoding* typeEncoding);
+    static void Register(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static v8::Local<v8::Value> FromPointer(v8::Local<v8::Context> context, v8::Local<v8::Value> type, void* handle);
+    static v8::Local<v8::Function> GetInteropReferenceCtorFunc(v8::Local<v8::Context> context);
+    static void* GetWrappedPointer(v8::Local<v8::Context> context, v8::Local<v8::Value> reference, const TypeEncoding* typeEncoding);
 private:
     struct DataPair {
         DataPair(const TypeEncoding* typeEncoding, void* data, size_t size): typeEncoding_(typeEncoding), data_(data), size_(size) {
@@ -22,15 +22,15 @@ private:
         size_t size_;
     };
 
-    static v8::Local<v8::Value> GetReferredValue(v8::Isolate* isolate, v8::Local<v8::Value> value);
+    static v8::Local<v8::Value> GetReferredValue(v8::Local<v8::Context> context, v8::Local<v8::Value> value);
     static void ReferenceConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void IndexedPropertyGetCallback(uint32_t index, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void IndexedPropertySetCallback(uint32_t index, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
 
     static void GetValueCallback(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void SetValueCallback(v8::Local<v8::Name> name, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void>& info);
-    static void RegisterToStringMethod(v8::Isolate* isolate, v8::Local<v8::Object> prototype);
-    static DataPair GetTypeEncodingDataPair(v8::Isolate* isolate, v8::Local<v8::Object> obj);
+    static void RegisterToStringMethod(v8::Local<v8::Context> context, v8::Local<v8::Object> prototype);
+    static DataPair GetTypeEncodingDataPair(v8::Local<v8::Object> obj);
 };
 
 }

--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -12,7 +12,8 @@ class Runtime {
 public:
     Runtime();
     ~Runtime();
-    void Init();
+    v8::Isolate* CreateIsolate();
+    void Init(v8::Isolate* isolate);
     void RunMainScript();
     void RunScript(std::string file, v8::TryCatch& tc);
     v8::Isolate* GetIsolate();

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -10,6 +10,7 @@
 #include "SimpleAllocator.h"
 #include "ObjectManager.h"
 #include "RuntimeConfig.h"
+#include "PromiseProxy.h"
 #include "Helpers.h"
 #include "TSHelpers.h"
 #include "WeakRef.h"
@@ -92,6 +93,7 @@ void Runtime::Init(Isolate* isolate) {
 
     DefineGlobalObject(context);
     DefineCollectFunction(context);
+    PromiseProxy::Init(context);
     Console::Init(context);
     this->moduleInternal_ = std::make_unique<ModuleInternal>(context);
 

--- a/NativeScript/runtime/SymbolIterator.mm
+++ b/NativeScript/runtime/SymbolIterator.mm
@@ -79,7 +79,7 @@ void SymbolIterator::NextCallback(const v8::FunctionCallbackInfo<v8::Value>& arg
         } else if ([item isKindOfClass:[NSString class]]) {
             val = tns::ToV8String(isolate, [item UTF8String]);
         } else {
-            val = ArgConverter::CreateJsWrapper(isolate, new ObjCDataWrapper(item), Local<Object>());
+            val = ArgConverter::CreateJsWrapper(context, new ObjCDataWrapper(item), Local<Object>());
         }
 
         bool success = obj->Set(context, tns::ToV8String(isolate, "done"), v8::Boolean::New(isolate, false)).FromMaybe(false);

--- a/NativeScript/runtime/TSHelpers.cpp
+++ b/NativeScript/runtime/TSHelpers.cpp
@@ -6,7 +6,7 @@ using namespace v8;
 
 namespace tns {
 
-void TSHelpers::Init(Isolate* isolate) {
+void TSHelpers::Init(Local<Context> context) {
     // The purpose of this script is to handle the "new" operator when extending native classes:
     //
     // var InheritingClass = (function (_super) {
@@ -127,7 +127,7 @@ void TSHelpers::Init(Isolate* isolate) {
         "    Object.defineProperty(global, \"__extends\", { value: __extends, writable: false });"
         "})()";
 
-    Local<Context> context = isolate->GetCurrentContext();
+    Isolate* isolate = context->GetIsolate();
     Local<Script> script;
     TryCatch tc(isolate);
     if (!Script::Compile(context, tns::ToV8String(isolate, source.c_str())).ToLocal(&script) && tc.HasCaught()) {

--- a/NativeScript/runtime/TSHelpers.h
+++ b/NativeScript/runtime/TSHelpers.h
@@ -7,7 +7,7 @@ namespace tns {
 
 class TSHelpers {
 public:
-    static void Init(v8::Isolate* isolate);
+    static void Init(v8::Local<v8::Context> context);
 };
 
 }

--- a/TestRunner/app/tests/Promises.js
+++ b/TestRunner/app/tests/Promises.js
@@ -1,5 +1,130 @@
 describe("Promise scheduling", function () {
-   it("should be executed", function(done) {
-       Promise.resolve().then(done); 
-   });
+    it("should be executed", function(done) {
+        Promise.resolve().then(done);
+    });
+
+    it("the 'then' callback should be executed on the same thread on which the Promise was created", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        const expectedResult = {
+            message: "ok"
+        };
+
+        new Promise((resolve, reject) => {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => resolve(expectedResult));
+        }).then(res => {
+            expect(res).toBe(expectedResult);
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+        }).catch(e => {
+            expect(true).toBe(false, "The catch callback of the promise was called");
+            done();
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            done();
+        });
+    });
+
+    it("the 'then' callback (with onRejected handler) should be executed on the same thread on which the Promise was created", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        const expectedResult = {
+            message: "ok"
+        };
+
+        new Promise((resolve, reject) => {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => resolve(expectedResult));
+        }).then(res => {
+            expect(res).toBe(expectedResult);
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+        }, e => {
+            expect(true).toBe(false, "The catch callback of the promise was called");
+            done();
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            done();
+        });
+    });
+
+    it("the 'catch' callback should be executed on the same thread on which the Promise was created", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        const expectedError = new Error("oops");
+
+        new Promise((resolve, reject) => {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => reject(expectedError));
+        }).then(res => {
+            expect(true).toBe(false, "The then callback of the promise was called");
+            done();
+        }).catch(e => {
+            expect(e).toBe(expectedError);
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            done();
+        });
+    });
+
+    it("the 'catch' callback (with onRejected handler) should be executed on the same thread on which the Promise was created", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        const expectedError = new Error("oops");
+
+        new Promise((resolve, reject) => {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => reject(expectedError));
+        }).then(res => {
+            expect(true).toBe(false, "The then callback of the promise was called");
+            done();
+        }, e => {
+            expect(e).toBe(expectedError);
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            done();
+        });
+    });
+
+    it("the 'finally' callback should be executed on the same thread on which the Promise was created", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        const expectedResult = {
+            message: "ok"
+        };
+
+        new Promise((resolve, reject) => {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => resolve(expectedResult));
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            done();
+        });
+    });
+
+    it("chaining promises with return values", done => {
+        const expectedHash = NSThread.currentThread.hash;
+        let expectedValues = [1, 2, 4, 8];
+        let actualValues = [];
+
+        new Promise(function(resolve, reject) {
+            let queue = NSOperationQueue.alloc().init();
+            queue.addOperationWithBlock(() => resolve(1));
+        }).then(value => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            actualValues.push(value);
+            return value * 2;
+        }).then(value => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            actualValues.push(value);
+            return new Promise((res, rej) => setTimeout(() => res(value * 2), 50));
+        }).then(value => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            actualValues.push(value);
+            return Promise.resolve(value * 2);
+        }).then(value => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            actualValues.push(value);
+        }).finally(() => {
+            expect(NSThread.currentThread.hash).toBe(expectedHash);
+            expect(actualValues).toEqual(expectedValues);
+            done();
+        });
+    });
 });

--- a/TestRunner/app/tests/shared/Workers/index.js
+++ b/TestRunner/app/tests/shared/Workers/index.js
@@ -471,12 +471,13 @@ describe("TNS Workers", () => {
             }, 1000);
         });
 
-        it("Worker should marshal callbacks on the worker thread even if the native callback was invoked on a different thread", done => {
-            let  worker = new Worker("./tests/shared/Workers/EvalWorker.js");
+        it("Worker should marshal callbacks on the same thread that the native block was invoked on", done => {
+            let worker = new Worker("./tests/shared/Workers/EvalWorker.js");
 
             worker.onmessage = msg => {
-                expect(msg.data.callingThreadHash).toEqual(msg.data.callbackThreadHash);
-                expect(msg.data.callingThreadHash).not.toEqual(NSThread.currentThread.hash);
+                expect(msg.data.callingThreadHash).not.toEqual(msg.data.callbackThreadHash);
+                expect(msg.data.callbackThreadHash).toEqual(NSThread.currentThread.hash);
+                worker.terminate();
                 done();
             };
 

--- a/v8ios.xcodeproj/project.pbxproj
+++ b/v8ios.xcodeproj/project.pbxproj
@@ -374,6 +374,8 @@
 		C2D7E9CD23F4024200DB289C /* error_support.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D7E9CC23F4024200DB289C /* error_support.h */; };
 		C2D7E9CF23F4294800DB289C /* export-template.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D7E9CE23F4294800DB289C /* export-template.h */; };
 		C2D7E9D223F4297400DB289C /* handle-for.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D7E9D123F4297400DB289C /* handle-for.h */; };
+		C2D7E9D523F42C1100DB289C /* PromiseProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D7E9D323F42C1100DB289C /* PromiseProxy.h */; };
+		C2D7E9D623F42C1100DB289C /* PromiseProxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2D7E9D423F42C1100DB289C /* PromiseProxy.cpp */; };
 		C2DDEB8D229EAC8300345BFE /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB64229EAC8100345BFE /* Common.h */; };
 		C2DDEB8E229EAC8300345BFE /* Interop.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB65229EAC8100345BFE /* Interop.h */; };
 		C2DDEB8F229EAC8300345BFE /* ArgConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DDEB66229EAC8100345BFE /* ArgConverter.h */; };
@@ -944,6 +946,8 @@
 		C2D7E9CC23F4024200DB289C /* error_support.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error_support.h; sourceTree = "<group>"; };
 		C2D7E9CE23F4294800DB289C /* export-template.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "export-template.h"; sourceTree = "<group>"; };
 		C2D7E9D123F4297400DB289C /* handle-for.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "handle-for.h"; sourceTree = "<group>"; };
+		C2D7E9D323F42C1100DB289C /* PromiseProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PromiseProxy.h; sourceTree = "<group>"; };
+		C2D7E9D423F42C1100DB289C /* PromiseProxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PromiseProxy.cpp; sourceTree = "<group>"; };
 		C2DDEB16229EA89000345BFE /* TestRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2DDEB26229EA89200345BFE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2DDEB32229EAB3B00345BFE /* NativeScript.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NativeScript.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1840,6 +1844,8 @@
 				C2DDEB86229EAC8300345BFE /* ObjectManager.mm */,
 				C266569222AFFF7E00EE15CC /* Pointer.h */,
 				C266569122AFFF7E00EE15CC /* Pointer.cpp */,
+				C2D7E9D323F42C1100DB289C /* PromiseProxy.h */,
+				C2D7E9D423F42C1100DB289C /* PromiseProxy.cpp */,
 				C266569622AFFFB000EE15CC /* Reference.h */,
 				C266569522AFFFB000EE15CC /* Reference.cpp */,
 				C2D71D7523E18C41000CD5F0 /* robin_hood.h */,
@@ -1941,6 +1947,7 @@
 				C247C35522F828E3001D2CA2 /* search-util.h in Headers */,
 				C266567C22AA630F00EE15CC /* NSDataAdapter.h in Headers */,
 				C247C35E22F828E3001D2CA2 /* Protocol.h in Headers */,
+				C2D7E9D523F42C1100DB289C /* PromiseProxy.h in Headers */,
 				C247C35922F828E3001D2CA2 /* value-mirror.h in Headers */,
 				C2A5F86B2359AEB600074AFA /* ExtVector.h in Headers */,
 				C2DDEBB0229EAC8300345BFE /* StringHasher.h in Headers */,
@@ -2606,6 +2613,7 @@
 				C2DDEBA0229EAC8300345BFE /* Interop.mm in Sources */,
 				C247C34822F828E3001D2CA2 /* custom-preview.cc in Sources */,
 				C247C35D22F828E3001D2CA2 /* CSS.cpp in Sources */,
+				C2D7E9D623F42C1100DB289C /* PromiseProxy.cpp in Sources */,
 				C266569E22B282BA00EE15CC /* FunctionReference.cpp in Sources */,
 				C247C36222F828E3001D2CA2 /* Page.cpp in Sources */,
 				C2229973235449B400C1DFD6 /* InspectorServer.mm in Sources */,


### PR DESCRIPTION
In this PR we are introducing `v8::Locker` objects to the codebase that allow accessing the isolate from multiple threads. This removes the need from marshalling javascript callbacks to the main thread.