### PR TITLE
fix: Register Swift classes with both native names

### DIFF
--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -604,7 +604,7 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
         std::string methodName = tns::ToString(isolate, key);
 
         Local<Value> propertyDescriptor;
-        tns::Assert(implementationObject->GetOwnPropertyDescriptor(context, key.As<Name>()).ToLocal(&propertyDescriptor), isolate);
+        tns::Assert(implementationObject->GetOwnPropertyDescriptor(context, key.As<v8::Name>()).ToLocal(&propertyDescriptor), isolate);
         if (propertyDescriptor.IsEmpty() || propertyDescriptor->IsNullOrUndefined()) {
             continue;
         }
@@ -795,7 +795,7 @@ void ClassBuilder::ExposeProperties(Isolate* isolate, Class extendedClass, std::
     }
 }
 
-void ClassBuilder::SuperAccessorGetterCallback(Local<Name> property, const PropertyCallbackInfo<Value>& info) {
+void ClassBuilder::SuperAccessorGetterCallback(Local<v8::Name> property, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
     Local<Object> thiz = info.This();

--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -56,6 +56,7 @@ inline uint8_t getMinorVersion(uint8_t encodedVersion) {
 
 // Bit indices in flags section
 enum MetaFlags {
+    HasDemangledName = 8,
     HasName = 7,
     // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but we never use it in the runtime
     FunctionReturnsUnmanaged = 3,
@@ -306,7 +307,7 @@ struct GlobalTable {
         return buckets.sizeInBytes();
     }
 
-    static const char* getName(const Meta& meta);
+    static bool compareName(const Meta& meta, const char* identifierString, size_t length);
 };
 
 struct ModuleTable {
@@ -533,14 +534,20 @@ public:
     }
 };
 
-struct JsNameAndName {
-    String jsName;
-    String name;
+enum NameIndex {
+    JsName,
+    Name,
+    DemangledName,
+    NameIndexCount,
+};
+
+struct JsNameAndNativeNames {
+    String strings[NameIndexCount];
 };
 
 union MetaNames {
     String name;
-    PtrTo<JsNameAndName> names;
+    PtrTo<JsNameAndNativeNames> names;
 };
 
 struct Meta {
@@ -548,7 +555,7 @@ struct Meta {
 private:
     MetaNames _names;
     PtrTo<ModuleMeta> _topLevelModule;
-    uint8_t _flags;
+    uint16_t _flags;
     uint8_t _introduced;
 
 public:
@@ -564,16 +571,24 @@ public:
         return this->flag(MetaFlags::HasName);
     }
 
+    bool hasDemangledName() const {
+        return this->flag(MetaFlags::HasDemangledName);
+    }
+
     bool flag(int index) const {
         return (this->_flags & (1 << index)) > 0;
     }
 
     const char* jsName() const {
-        return (this->hasName()) ? this->_names.names->jsName.valuePtr() : this->_names.name.valuePtr();
+        return this->getNameByIndex(JsName);
     }
 
     const char* name() const {
-        return (this->hasName()) ? this->_names.names->name.valuePtr() : this->jsName();
+        return this->getNameByIndex(Name);
+    }
+
+    const char* demangledName() const {
+        return this->getNameByIndex(DemangledName);
     }
 
     /**
@@ -592,6 +607,24 @@ public:
     * > have been introduced in this or prior version;
     */
     bool isAvailable() const;
+
+private:
+    const char* getNameByIndex(enum NameIndex index) const {
+        int i = index;
+        if (!this->hasName() && !this->hasDemangledName()) {
+            return this->_names.name.valuePtr();
+        }
+
+        if (!this->hasDemangledName() && i >= DemangledName) {
+            i--;
+        }
+
+        if (!this->hasName() && i >= Name) {
+            i--;
+        }
+
+        return this->_names.names.value().strings[i].valuePtr();
+    }
 };
 
 struct RecordMeta : Meta {

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -23,7 +23,7 @@ void MetadataBuilder::RegisterConstantsOnGlobalObject(Isolate* isolate, Local<Ob
     globalTemplate->SetHandler(config);
 }
 
-void MetadataBuilder::GlobalPropertyGetter(Local<Name> property, const PropertyCallbackInfo<Value>& info) {
+void MetadataBuilder::GlobalPropertyGetter(Local<v8::Name> property, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     std::string propName = tns::ToString(isolate, property);
 
@@ -669,7 +669,7 @@ void MetadataBuilder::PropertySetterCallback(const FunctionCallbackInfo<Value> &
     MetadataBuilder::InvokeMethod(context, item->meta_->setter(), receiver, args, item->className_, true);
 }
 
-void MetadataBuilder::PropertyNameGetterCallback(Local<Name> name, const PropertyCallbackInfo<Value> &info) {
+void MetadataBuilder::PropertyNameGetterCallback(Local<v8::Name> name, const PropertyCallbackInfo<Value> &info) {
     Isolate* isolate = info.GetIsolate();
     CacheItem<PropertyMeta>* item = static_cast<CacheItem<PropertyMeta>*>(info.Data().As<External>()->Value());
     if (!item->meta_->hasGetter()) {
@@ -686,7 +686,7 @@ void MetadataBuilder::PropertyNameGetterCallback(Local<Name> name, const Propert
     }
 }
 
-void MetadataBuilder::PropertyNameSetterCallback(Local<Name> name, Local<Value> value, const PropertyCallbackInfo<void> &info) {
+void MetadataBuilder::PropertyNameSetterCallback(Local<v8::Name> name, Local<Value> value, const PropertyCallbackInfo<void> &info) {
     Isolate* isolate = info.GetIsolate();
     CacheItem<PropertyMeta>* item = static_cast<CacheItem<PropertyMeta>*>(info.Data().As<External>()->Value());
     if (!item->meta_->hasSetter()) {
@@ -700,7 +700,7 @@ void MetadataBuilder::PropertyNameSetterCallback(Local<Name> name, Local<Value> 
     MetadataBuilder::InvokeMethod(context, item->meta_->setter(), Local<Object>(), args, item->className_, false);
 }
 
-void MetadataBuilder::StructPropertyGetterCallback(Local<Name> property, const PropertyCallbackInfo<Value>& info) {
+void MetadataBuilder::StructPropertyGetterCallback(Local<v8::Name> property, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     Local<Object> thiz = info.This();
 
@@ -744,7 +744,7 @@ void MetadataBuilder::StructPropertyGetterCallback(Local<Name> property, const P
     info.GetReturnValue().Set(result);
 }
 
-void MetadataBuilder::StructPropertySetterCallback(Local<Name> property, Local<Value> value, const PropertyCallbackInfo<Value>& info) {
+void MetadataBuilder::StructPropertySetterCallback(Local<v8::Name> property, Local<Value> value, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
     Local<Object> thiz = info.This();
@@ -838,7 +838,7 @@ void MetadataBuilder::CFunctionCallback(const FunctionCallbackInfo<Value>& info)
     }
 }
 
-void MetadataBuilder::SwizzledInstanceMethodCallback(Local<Name> property, Local<Value> value, const PropertyCallbackInfo<Value>& info) {
+void MetadataBuilder::SwizzledInstanceMethodCallback(Local<v8::Name> property, Local<Value> value, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     std::string methodName = tns::ToString(isolate, property);
 
@@ -875,7 +875,7 @@ void MetadataBuilder::SwizzledInstanceMethodCallback(Local<Name> property, Local
     }
 }
 
-void MetadataBuilder::SwizzledPropertyCallback(Local<Name> property, const PropertyDescriptor& desc, const PropertyCallbackInfo<Value>& info) {
+void MetadataBuilder::SwizzledPropertyCallback(Local<v8::Name> property, const PropertyDescriptor& desc, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     std::string propertyName = tns::ToString(isolate, property);
 

--- a/NativeScript/runtime/MetadataInlines.h
+++ b/NativeScript/runtime/MetadataInlines.h
@@ -85,17 +85,21 @@ const Meta* GlobalTable<TYPE>::findMeta(const char* identifierString, size_t len
     const ArrayOfPtrTo<Meta>& bucketContent = buckets[bucketIndex].value();
     for (ArrayOfPtrTo<Meta>::iterator it = bucketContent.begin(); it != bucketContent.end(); it++) {
         const Meta* meta = (*it).valuePtr();
-        const char* name = getName(*meta);
-        if (compareIdentifiers(name, identifierString, length) == 0) {
+        if (this->compareName(*meta, identifierString, length)) {
             return onlyIfAvailable ? (meta->isAvailable() ? meta : nullptr) : meta;
         }
     }
     return nullptr;
 }
 
-template <GlobalTableType TYPE>
-inline const char* GlobalTable<TYPE>::getName(const Meta& meta) {
-    return TYPE == GlobalTableType::ByJsName ? meta.jsName() : meta.name();
+template <>
+inline bool GlobalTable<ByJsName>::compareName(const Meta& meta, const char* identifierString, size_t length) {
+    return compareIdentifiers(meta.jsName(), identifierString, length) == 0;
+}
+
+template <>
+inline bool GlobalTable<ByNativeName>::compareName(const Meta& meta, const char* identifierString, size_t length) {
+    return compareIdentifiers(meta.name(), identifierString, length) == 0 || (meta.hasDemangledName() && compareIdentifiers(meta.demangledName(), identifierString, length) == 0);
 }
 
 // GlobalTable::iterator

--- a/NativeScript/runtime/Reference.cpp
+++ b/NativeScript/runtime/Reference.cpp
@@ -118,7 +118,7 @@ void Reference::IndexedPropertySetCallback(uint32_t index, Local<Value> value, c
     Interop::WriteValue(context, typeEncoding, ptr, value);
 }
 
-void Reference::GetValueCallback(Local<Name> name, const PropertyCallbackInfo<Value>& info) {
+void Reference::GetValueCallback(Local<v8::Name> name, const PropertyCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     Local<Context> context = isolate->GetCurrentContext();
     Local<Value> result = Reference::GetReferredValue(context, info.This());
@@ -129,7 +129,7 @@ void Reference::GetValueCallback(Local<Name> name, const PropertyCallbackInfo<Va
     }
 }
 
-void Reference::SetValueCallback(Local<Name> name, Local<Value> value, const PropertyCallbackInfo<void>& info) {
+void Reference::SetValueCallback(Local<v8::Name> name, Local<Value> value, const PropertyCallbackInfo<void>& info) {
     Isolate* isolate = info.GetIsolate();
     BaseDataWrapper* baseWrapper = tns::GetValue(isolate, info.This());
     tns::Assert(baseWrapper->Type() == WrapperType::Reference, isolate);

--- a/TestRunner/app/tests/MetadataTests.js
+++ b/TestRunner/app/tests/MetadataTests.js
@@ -9,7 +9,10 @@ describe("Metadata", function () {
         expect(global.TNSSwiftLikeFactory.name).toBe("TNSSwiftLikeFactory");
         const swiftLikeObj = TNSSwiftLikeFactory.create();
         expect(swiftLikeObj.constructor).toBe(global.TNSSwiftLike);
-        expect(swiftLikeObj.constructor.name).toBe("NativeScriptTests.TNSSwiftLike");
-        expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe("NativeScriptTests.TNSSwiftLike");
+        expect(swiftLikeObj.constructor.name).toBe("_TtC17NativeScriptTests12TNSSwiftLike");
+        var expectedName = NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({ majorVersion: 13, minorVersion: 4, patchVersion: 0 })
+            ? "_TtC17NativeScriptTests12TNSSwiftLike"
+            : "NativeScriptTests.TNSSwiftLike";
+        expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe(expectedName);
     });
 });

--- a/metadata-generator/build-step-metadata-generator.py
+++ b/metadata-generator/build-step-metadata-generator.py
@@ -37,6 +37,7 @@ def map_and_list(func, iterable):
 # process environment variables
 conf_build_dir = env("CONFIGURATION_BUILD_DIR")
 sdk_root = env("SDKROOT")
+src_root = env("SRCROOT")
 deployment_target_flag_name = env("DEPLOYMENT_TARGET_CLANG_FLAG_NAME")
 deployment_target = env(env("DEPLOYMENT_TARGET_CLANG_ENV_NAME"))
 std = env("GCC_C_LANGUAGE_STANDARD")
@@ -46,8 +47,6 @@ framework_search_paths = env_or_empty("FRAMEWORK_SEARCH_PATHS")
 framework_search_paths_parsed = map_and_list((lambda s: "-F" + s), shlex.split(framework_search_paths))
 other_cflags = env_or_empty("OTHER_CFLAGS")
 other_cflags_parsed = shlex.split(other_cflags)
-system_framework_search_paths = env_or_empty("SYSTEM_FRAMEWORK_SEARCH_PATHS")
-system_framework_search_paths_parsed = map_and_list((lambda s: "-F" + s), shlex.split(system_framework_search_paths))
 enable_modules = env_bool("CLANG_ENABLE_MODULES")
 preprocessor_defs = env_or_empty("GCC_PREPROCESSOR_DEFINITIONS")
 preprocessor_defs_parsed = map_and_list((lambda s: "-D" + s), shlex.split(preprocessor_defs, '\''))
@@ -99,6 +98,14 @@ def generate_metadata(arch):
         generator_call.extend(["-output-yaml", current_yaml_output_folder])
         print("Generating debug metadata in: \"{}\"".format(current_yaml_output_folder))
 
+    whitelist_file_name = os.path.join(src_root, "whitelist.mdg")
+    if os.path.exists(whitelist_file_name):
+      generator_call.extend(["--whitelist-modules-file", whitelist_file_name])
+
+    blacklist_file_name = os.path.join(src_root, "blacklist.mdg")
+    if os.path.exists(blacklist_file_name):
+      generator_call.extend(["--blacklist-modules-file", blacklist_file_name])
+
     # clang arguments
     generator_call.extend(["Xclang",
                            "-isysroot", sdk_root,
@@ -112,7 +119,6 @@ def generate_metadata(arch):
 
     generator_call.extend(header_search_paths_parsed)  # HEADER_SEARCH_PATHS
     generator_call.extend(framework_search_paths_parsed)  # FRAMEWORK_SEARCH_PATHS
-    generator_call.extend(system_framework_search_paths_parsed)  # SYSTEM_FRAMEWORK_SEARCH_PATHS
     generator_call.extend(other_cflags_parsed)  # OTHER_CFLAGS
     generator_call.extend(preprocessor_defs_parsed)  # GCC_PREPROCESSOR_DEFINITIONS
 

--- a/metadata-generator/src/Binary/binaryStructures.cpp
+++ b/metadata-generator/src/Binary/binaryStructures.cpp
@@ -5,7 +5,7 @@ binary::MetaFileOffset binary::Meta::save(BinaryWriter& writer)
 {
     binary::MetaFileOffset offset = writer.push_pointer(this->_names);
     writer.push_pointer(this->_topLevelModule);
-    writer.push_byte(this->_flags);
+    writer.push_short(this->_flags);
     writer.push_byte(this->_introduced);
     return offset;
 }

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -60,8 +60,9 @@ enum BinaryMetaType : uint8_t {
     Protocol
 };
 
-enum BinaryFlags : uint8_t {
+enum BinaryFlags : uint16_t {
     // Common
+    HasDemangledName = 1 << 8,
     HasName = 1 << 7,
     IsIosAppExtensionAvailable = 1 << 6,
     // Function
@@ -85,13 +86,13 @@ enum BinaryFlags : uint8_t {
 struct Meta {
 public:
     Meta(BinaryMetaType type)
-        : _flags(type & 7) // 7 = 111 -> get only the first 3 bits of the type
+        : _flags(type & 0x7) // 7 = 111 -> get only the first 3 bits of the type
     {
     }
 
     MetaFileOffset _names = 0;
     MetaFileOffset _topLevelModule = 0;
-    uint8_t _flags = 0;
+    uint16_t _flags = 0;
     uint8_t _introduced = 0;
 
     virtual MetaFileOffset save(BinaryWriter& writer);

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
@@ -127,7 +127,7 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitId(c
     auto s = llvm::make_unique<binary::IdEncoding>();
     std::vector<MetaFileOffset> offsets;
     for (auto protocol : type.protocols) {
-        offsets.push_back(this->_heapWriter.push_string(protocol->jsName));
+        offsets.push_back(this->_heapWriter.push_string(protocol->name));
     }
     s->_protocols = this->_heapWriter.push_binaryArray(offsets);
 
@@ -152,11 +152,11 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitInco
 unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitInterface(const ::Meta::InterfaceType& type)
 {
     auto* s = new binary::InterfaceDeclarationReferenceEncoding();
-    s->_name = this->_heapWriter.push_string(type.interface->jsName);
+    s->_name = this->_heapWriter.push_string(type.interface->name);
     
     std::vector<MetaFileOffset> offsets;
     for (auto protocol : type.protocols) {
-        offsets.push_back(this->_heapWriter.push_string(protocol->jsName));
+        offsets.push_back(this->_heapWriter.push_string(protocol->name));
     }
     s->_protocols = this->_heapWriter.push_binaryArray(offsets);
     
@@ -172,7 +172,7 @@ unique_ptr<binary::TypeEncoding> binary::BinaryTypeEncodingSerializer::visitBrid
         throw logic_error(std::string("Unresolved bridged interface for BridgedInterfaceType with name '") + type.name + "'.");
     }
     auto s = new binary::InterfaceDeclarationReferenceEncoding();
-    s->_name = this->_heapWriter.push_string(type.bridgedInterface->jsName);
+    s->_name = this->_heapWriter.push_string(type.bridgedInterface->name);
 
     std::vector<MetaFileOffset> offsets;
     s->_protocols = this->_heapWriter.push_binaryArray(offsets);

--- a/metadata-generator/src/Binary/binaryWriter.h
+++ b/metadata-generator/src/Binary/binaryWriter.h
@@ -28,6 +28,13 @@ public:
     }
 
     /*
+         * \brief Gets current stream position.
+         */
+    MetaFileOffset currentPosition() const {
+        return this->_stream->position();
+    }
+
+    /*
          * \brief Writes a nil terminated string.
          * \param str
          * \param shouldIntern Specifies if this string should be unique in this stream. Default \c true

--- a/metadata-generator/src/Binary/metaFile.cpp
+++ b/metadata-generator/src/Binary/metaFile.cpp
@@ -10,10 +10,12 @@ void binary::MetaFile::registerInGlobalTables(const ::Meta::Meta& meta, binary::
 {
     this->_globalTableSymbolsJs->add(meta.jsName, offset);
 
-    if (meta.type == ::Meta::MetaType::Protocol) {
-        this->_globalTableSymbolsNativeProtocols->add(meta.name, offset);
-    } else if (meta.type == ::Meta::MetaType::Interface) {
-        this->_globalTableSymbolsNativeInterfaces->add(meta.name, offset);
+    auto& nativeTable = (meta.type == ::Meta::MetaType::Protocol) ? this->_globalTableSymbolsNativeProtocols : this->_globalTableSymbolsNativeInterfaces;
+
+    nativeTable->add(meta.name, offset);
+
+    if (!meta.demangledName.empty()) {
+        nativeTable->add(meta.demangledName, offset);
     }
 }
 

--- a/metadata-generator/src/Binary/metaFile.h
+++ b/metadata-generator/src/Binary/metaFile.h
@@ -38,7 +38,7 @@ public:
          */
     MetaFile(int size)
     {
-         size = std::max(size, 100);
+        size = std::max(size, 100);
         this->_globalTableSymbolsJs = std::unique_ptr<BinaryHashtable>(new BinaryHashtable(size));
         this->_globalTableSymbolsNativeProtocols = std::unique_ptr<BinaryHashtable>(new BinaryHashtable(size/10));
         this->_globalTableSymbolsNativeInterfaces = std::unique_ptr<BinaryHashtable>(new BinaryHashtable(size/10));

--- a/metadata-generator/src/HeadersParser/Parser.cpp
+++ b/metadata-generator/src/HeadersParser/Parser.cpp
@@ -83,7 +83,7 @@ static std::error_code collectModuleHeaderIncludes(FileManager& fileMgr, ModuleM
     return std::error_code();
 }
 
-static std::error_code CreateUmbrellaHeaderForAmbientModules(const std::vector<std::string>& args, std::vector<SmallString<256>>& umbrellaHeaders, const std::vector<std::string>& moduleBlacklist, std::vector<std::string>& includePaths)
+static std::error_code CreateUmbrellaHeaderForAmbientModules(const std::vector<std::string>& args, std::vector<SmallString<256>>& umbrellaHeaders, std::vector<std::string>& includePaths)
 {
     std::unique_ptr<clang::ASTUnit> ast = clang::tooling::buildASTFromCodeWithArgs("", args, "umbrella.h");
     if (!ast)
@@ -106,8 +106,6 @@ static std::error_code CreateUmbrellaHeaderForAmbientModules(const std::vector<s
 //            clang::Module* sm;
 //            module->isAvailable(ast->getPreprocessor().getLangOpts(), ast->getPreprocessor().getTargetInfo(), req, h, sm);
 //        }
-        if (std::find(moduleBlacklist.begin(), moduleBlacklist.end(), module->getFullModuleName()) != moduleBlacklist.end())
-            return;
 
         // use -idirafter instead of -I in order  add the directories AFTER the include search paths
         std::string includeString = "-idirafter" + module->Directory->getName().str();
@@ -136,11 +134,9 @@ int headerPriority(SmallString<256> h) {
 
 std::string CreateUmbrellaHeader(const std::vector<std::string>& clangArgs, std::vector<std::string>& includePaths)
 {
-    std::vector<std::string> moduleBlacklist;
-
     // Generate umbrella header for all modules from the sdk
     std::vector<SmallString<256>> umbrellaHeaders;
-    CreateUmbrellaHeaderForAmbientModules(clangArgs, umbrellaHeaders, moduleBlacklist, includePaths);
+    CreateUmbrellaHeaderForAmbientModules(clangArgs, umbrellaHeaders, includePaths);
 
     std::stable_sort(umbrellaHeaders.begin(), umbrellaHeaders.end(), [](const SmallString<256>& h1, const SmallString<256>& h2) {
         return headerPriority(h1) < headerPriority(h2);

--- a/metadata-generator/src/Meta/Filters/ModulesBlacklist.h
+++ b/metadata-generator/src/Meta/Filters/ModulesBlacklist.h
@@ -1,0 +1,128 @@
+//
+//  ModulesBlacklist.h
+//  MetadataGenerator
+//
+//  Created by Martin Bekchiev on 13.01.20.
+//
+
+#ifndef ModulesBlacklist_h
+#define ModulesBlacklist_h
+
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Regex.h>
+
+namespace Meta {
+
+class ModulesBlacklist {
+private:
+    struct ModuleAndSymbolNamePatterns {
+        std::string modulePattern;
+        std::string symbolPattern;
+        
+        std::string toString() {
+            return this->modulePattern + ":" + this->symbolPattern;
+        }
+    };
+    typedef std::vector<ModuleAndSymbolNamePatterns> ModuleAndSymbolNamePatternsList;
+
+public:
+    ModulesBlacklist(std::string& whitelistFileName, std::string& blacklistFileName) {
+        this->_whitelistDefined = !whitelistFileName.empty();
+        fillPatternsFromFile(whitelistFileName, /*r*/this->_whitelist);
+        fillPatternsFromFile(blacklistFileName, /*r*/this->_blacklist);
+    }
+
+    bool shouldBlacklist(std::string moduleName, std::string symbolName, std::string& enabledBy, std::string& disabledBy) {
+        auto findMatchingPattern = [&moduleName, &symbolName](ModuleAndSymbolNamePatternsList& v) {
+            return std::find_if(v.begin(), v.end(), [&moduleName, &symbolName](ModuleAndSymbolNamePatterns& item) {
+                return
+                    (item.modulePattern.empty() ||
+                     match(item.modulePattern.c_str(), moduleName.c_str()))
+                &&
+                    (item.symbolPattern.empty() ||
+                     match(item.symbolPattern.c_str(), symbolName.c_str()));
+            });
+        };
+        
+        bool enabledByWhitelist = true;
+        if (this->_whitelistDefined) {
+            auto it = findMatchingPattern(this->_whitelist);
+            enabledByWhitelist = it != this->_whitelist.end();
+            if (enabledByWhitelist) {
+                enabledBy = it->toString();
+            }
+        }
+        
+        auto itBlacklist = findMatchingPattern(this->_blacklist);
+        bool disabledByBlacklist = itBlacklist != this->_blacklist.end();
+        if (disabledByBlacklist) {
+            disabledBy = itBlacklist->toString();
+        }
+
+        return disabledByBlacklist || !enabledByWhitelist;
+    }
+
+private:
+    // Taken from https://www.geeksforgeeks.org/wildcard-character-matching/
+    static bool match(const char* pattern, const char* string)
+    {
+        // If we reach at the end of both strings, we are done
+        if (*pattern == '\0' && *string == '\0')
+            return true;
+        
+        // pattern "*" matches everything, done checking
+        if (pattern[0] == '*' && pattern[1] == '\0')
+            return true;
+        
+        // Make sure that the characters after '*' are present
+        // in second string. This function assumes that the first
+        // string will not contain two consecutive '*'
+        if (*pattern == '*' && *(pattern+1) != '\0' && *string == '\0')
+            return false;
+      
+        // If the first string contains '?', or current characters
+        // of both strings match
+        if (*pattern == '?' || *pattern == *string)
+            return match(pattern+1, string+1);
+      
+        // If there is *, then there are two possibilities
+        // a) We consider current character of second string
+        // b) We ignore current character of second string.
+        if (*pattern == '*')
+            return match(pattern+1, string) || match(pattern, string+1);
+        return false;
+    }
+    
+    static void fillPatternsFromFile(const std::string& opt, ModuleAndSymbolNamePatternsList &regexList) {
+        if (!opt.empty()) {
+            std::ifstream ifs(opt);
+            
+            if (!ifs) {
+                std::stringstream ss;
+                ss << "Specified patterns list file " << opt << " not found." << std::endl;
+                throw std::invalid_argument(ss.str());
+            }
+            
+            std::string line;
+            while (std::getline(ifs, line)) {
+                if (line.size() && strncmp(line.c_str(), "#", 1) != 0 && strncmp(line.c_str(), "//", 2) != 0) { // ignore comments and empty lines
+                    std::size_t colon = line.find(':');
+                    std::string modulePattern = line.substr(0, colon);
+                    std::string symbolPattern = colon != std::string::npos ? line.substr(colon+1) : std::string();
+                    regexList.push_back({ modulePattern, symbolPattern });
+                }
+            }
+        }
+    }
+
+    bool _whitelistDefined = false;
+    ModuleAndSymbolNamePatternsList _whitelist;
+    ModuleAndSymbolNamePatternsList _blacklist;
+};
+
+} // namespace Meta
+
+#endif /* ModulesBlacklist_h */

--- a/metadata-generator/src/Meta/MetaEntities.h
+++ b/metadata-generator/src/Meta/MetaEntities.h
@@ -104,6 +104,7 @@ public:
     MetaFlags flags = MetaFlags::None;
 
     std::string name;
+    std::string demangledName;
     std::string jsName;
     std::string fileName;
     clang::Module* module = nullptr;

--- a/metadata-generator/src/TypeScript/DefinitionWriter.cpp
+++ b/metadata-generator/src/TypeScript/DefinitionWriter.cpp
@@ -681,7 +681,7 @@ void DefinitionWriter::visit(FunctionMeta* meta)
     std::ostringstream params;
     for (size_t i = 1; i < meta->signature.size(); i++) {
         std::string name = sanitizeParameterName(functionDecl.getParamDecl(i - 1)->getNameAsString());
-        params << (name.size() ? name : "p" + std::to_string(i)) << ": " << tsifyType(*meta->signature[i]);
+        params << (name.size() ? name : "p" + std::to_string(i)) << ": " << tsifyType(*meta->signature[i], true);
         if (i < meta->signature.size() - 1) {
             params << ", ";
         }

--- a/metadata-generator/src/Yaml/MetaYamlTraits.h
+++ b/metadata-generator/src/Yaml/MetaYamlTraits.h
@@ -234,7 +234,7 @@ namespace yaml {
             }
             case Meta::TypeType::TypeInterface: {
                 Meta::InterfaceType& concreteType = type->as<Meta::InterfaceType>();
-                io.mapRequired("JsName", concreteType.interface->jsName);
+                io.mapRequired("Name", concreteType.interface->name);
                 if (concreteType.typeArguments.size() > 0) {
                     std::vector<Meta::Type*> typeArguments;
                     for (Meta::Type* type : concreteType.typeArguments) {
@@ -275,14 +275,14 @@ namespace yaml {
                 Meta::StructType& concreteType = type->as<Meta::StructType>();
                 std::string fullModuleName = concreteType.structMeta->module->getFullModuleName();
                 io.mapRequired("Module", fullModuleName);
-                io.mapRequired("JsName", concreteType.structMeta->jsName);
+                io.mapRequired("Name", concreteType.structMeta->name);
                 break;
             }
             case Meta::TypeType::TypeUnion: {
                 Meta::UnionType& concreteType = type->as<Meta::UnionType>();
                 std::string fullModuleName = concreteType.unionMeta->module->getFullModuleName();
                 io.mapRequired("Module", fullModuleName);
-                io.mapRequired("JsName", concreteType.unionMeta->jsName);
+                io.mapRequired("Name", concreteType.unionMeta->name);
                 break;
             }
             case Meta::TypeType::TypeAnonymousStruct: {
@@ -323,6 +323,9 @@ namespace yaml {
     {
         io.mapRequired("Name", meta->name);
         io.mapRequired("JsName", meta->jsName);
+        if (!meta->demangledName.empty()) {
+            io.mapRequired("DemangledName", meta->demangledName);
+        }
         io.mapRequired("Filename", meta->fileName);
         io.mapRequired("Module", meta->module);
         io.mapOptional("IntroducedIn", meta->introducedIn, UNKNOWN_VERSION);


### PR DESCRIPTION
The Objective-C runtime doesn't behave consistently with Swift class
names. Sometimes the mangled name can only be used, other times
the demangled one. To avoid hardcoding any logic which may get
easily broken in the future, we are adding both names in the global
tables and using the mangled name in signatures.

Observation which lead to this change:

* `objc_getClass(const char *)` - accepts both mangled and demangled
names of Swift classes which are not nested in another class. Nested
classes however can be discovered only by their mangled name.

* `class_getName` - returns the demangled name for Swift classes
which aren't nested, and the mangled one for nested.

* On Mac Catalyst `class_getName` returns  the mangled names
no matter whether the class is nested or not.