### PR TITLE
fix: Runtime cleanup #51

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -651,7 +651,7 @@ const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding
     }
 
     std::string origClassName = class_getName(klass);
-    const Meta* meta = Caches::Metadata.Get(origClassName);
+    const Meta* meta = Caches::Metadata->Get(origClassName);
     if (meta != nullptr) {
         return meta;
     }
@@ -661,7 +661,7 @@ const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding
     while (true) {
         const Meta* result = GetMeta(className);
         if (result != nullptr && result->type() == MetaType::Interface) {
-            Caches::Metadata.Insert(origClassName, result);
+            Caches::Metadata->Insert(origClassName, result);
             return result;
         }
 
@@ -678,7 +678,7 @@ const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding
 
 const Meta* ArgConverter::GetMeta(std::string name) {
     bool found;
-    const Meta* meta = Caches::Metadata.Get(name, found);
+    const Meta* meta = Caches::Metadata->Get(name, found);
     if (meta != nullptr || found) {
         return meta;
     }
@@ -696,7 +696,7 @@ const Meta* ArgConverter::GetMeta(std::string name) {
         }
     }
 
-    Caches::Metadata.Insert(name, result);
+    Caches::Metadata->Insert(name, result);
 
     return result;
 }

--- a/NativeScript/runtime/Caches.cpp
+++ b/NativeScript/runtime/Caches.cpp
@@ -24,17 +24,17 @@ Caches::~Caches() {
 }
 
 std::shared_ptr<Caches> Caches::Get(Isolate* isolate) {
-    std::shared_ptr<Caches> cache = Caches::perIsolateCaches_.Get(isolate);
+    std::shared_ptr<Caches> cache = perIsolateCaches_->Get(isolate);
     if (cache == nullptr) {
         cache = std::make_shared<Caches>(isolate);
-        Caches::perIsolateCaches_.Insert(isolate, cache);
+        Caches::perIsolateCaches_->Insert(isolate, cache);
     }
 
     return cache;
 }
 
 void Caches::Remove(v8::Isolate* isolate) {
-    Caches::perIsolateCaches_.Remove(isolate);
+    Caches::perIsolateCaches_->Remove(isolate);
 }
 
 void Caches::SetContext(Local<Context> context) {
@@ -45,9 +45,9 @@ Local<Context> Caches::GetContext() {
     return this->context_->Get(this->isolate_);
 }
 
-ConcurrentMap<Isolate*, std::shared_ptr<Caches>> Caches::perIsolateCaches_;
+std::shared_ptr<ConcurrentMap<Isolate*, std::shared_ptr<Caches>>> Caches::perIsolateCaches_ = std::make_shared<ConcurrentMap<Isolate*, std::shared_ptr<Caches>>>();
 
-ConcurrentMap<std::string, const Meta*> Caches::Metadata;
-ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>> Caches::Workers;
+std::shared_ptr<ConcurrentMap<std::string, const Meta*>> Caches::Metadata = std::make_shared<ConcurrentMap<std::string, const Meta*>>();
+std::shared_ptr<ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>>> Caches::Workers = std::make_shared<ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>>>();
 
 }

--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -48,8 +48,8 @@ public:
     Caches(v8::Isolate* isolate);
     ~Caches();
 
-    static ConcurrentMap<std::string, const Meta*> Metadata;
-    static ConcurrentMap<int, std::shared_ptr<WorkerState>> Workers;
+    static std::shared_ptr<ConcurrentMap<std::string, const Meta*>> Metadata;
+    static std::shared_ptr<ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>>> Workers;
 
     static std::shared_ptr<Caches> Get(v8::Isolate* isolate);
     static void Remove(v8::Isolate* isolate);
@@ -86,7 +86,7 @@ public:
     std::unique_ptr<v8::Persistent<v8::Function>> PointerCtorFunc = std::unique_ptr<v8::Persistent<v8::Function>>(nullptr);
     std::unique_ptr<v8::Persistent<v8::Function>> FunctionReferenceCtorFunc = std::unique_ptr<v8::Persistent<v8::Function>>(nullptr);
 private:
-    static ConcurrentMap<v8::Isolate*, std::shared_ptr<Caches>> perIsolateCaches_;
+    static std::shared_ptr<ConcurrentMap<v8::Isolate*, std::shared_ptr<Caches>>> perIsolateCaches_;
     v8::Isolate* isolate_;
     std::shared_ptr<v8::Persistent<v8::Context>> context_;
 };

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -40,9 +40,16 @@ Runtime::Runtime() {
 
 Runtime::~Runtime() {
     this->isolate_->TerminateExecution();
-    Caches::Workers.Remove(this->workerId_);
-    Caches::Remove(this->isolate_);
+
+    if (![NSThread isMainThread]) {
+        Caches::Workers->Remove(this->workerId_);
+        Caches::Remove(this->isolate_);
+    } else {
+        this->isolate_->Exit();
+    }
+
     this->isolate_->Dispose();
+
     currentRuntime_ = nullptr;
 }
 

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -95,7 +95,7 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
 
         std::shared_ptr<Caches::WorkerState> state = std::make_shared<Caches::WorkerState>(isolate, poWorker, worker);
         int workerId = worker->Id();
-        Caches::Workers.Insert(workerId, state);
+        Caches::Workers->Insert(workerId, state);
     } catch (NativeScriptException& ex) {
         ex.ReThrowToV8(isolate);
     }
@@ -115,7 +115,7 @@ void Worker::PostMessageToMainCallback(const FunctionCallbackInfo<Value>& info) 
         }
 
         int workerId = Worker::GetWorkerId(isolate, info.This());
-        std::shared_ptr<Caches::WorkerState> state = Caches::Workers.Get(workerId);
+        std::shared_ptr<Caches::WorkerState> state = Caches::Workers->Get(workerId);
         tns::Assert(state != nullptr, isolate);
         WorkerWrapper* worker = static_cast<WorkerWrapper*>(state->UserData());
         if (!worker->IsRunning()) {
@@ -206,7 +206,7 @@ void Worker::OnMessageCallback(Isolate* isolate, Local<Value> receiver, std::str
 void Worker::CloseWorkerCallback(const FunctionCallbackInfo<Value>& info) {
     Isolate* isolate = info.GetIsolate();
     int workerId = Worker::GetWorkerId(isolate, info.This());
-    std::shared_ptr<Caches::WorkerState> state = Caches::Workers.Get(workerId);
+    std::shared_ptr<Caches::WorkerState> state = Caches::Workers->Get(workerId);
     tns::Assert(state != nullptr, isolate);
     WorkerWrapper* worker = static_cast<WorkerWrapper*>(state->UserData());
 


### PR DESCRIPTION
Avoid double cache cleanup upon process exit.

Related to #51.