### PR TITLE
fix: Ensure Isolate is alive before using it (#63)

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -6,6 +6,7 @@
 #include "ObjectManager.h"
 #include "Interop.h"
 #include "Helpers.h"
+#include "Runtime.h"
 
 using namespace v8;
 using namespace std;
@@ -91,6 +92,12 @@ void ArgConverter::MethodCallback(ffi_cif* cif, void* retValue, void** argValues
     MethodCallbackWrapper* data = static_cast<MethodCallbackWrapper*>(userData);
 
     Isolate* isolate = data->isolate_;
+
+    if (!Runtime::IsAlive(isolate)) {
+        memset(retValue, 0, cif->rtype->size);
+        return;
+    }
+
     v8::Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);

--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -42,9 +42,12 @@ public:
     }
 
     static id GetAppConfigValue(std::string key);
+
+    static bool IsAlive(v8::Isolate* isolate);
 private:
     static thread_local Runtime* currentRuntime_;
     static std::shared_ptr<v8::Platform> platform_;
+    static std::vector<v8::Isolate*> isolates_;
     static bool mainThreadInitialized_;
 
     void DefineGlobalObject(v8::Local<v8::Context> context);


### PR DESCRIPTION
Related to #63.

Steps to reproduce:

```javascript
var worker = new Worker("./tests/shared/Workers/EvalWorker.js");

worker.onmessage = (msg) => {
    worker.terminate();
    NSNotificationCenter.defaultCenter.postNotificationNameObject("MyNotification", null);
};

const workerScript = `
  var NotificationObserver = /** @class */ (function (_super) {
    __extends(NotificationObserver, _super);
    function NotificationObserver() {
        return _super !== null && _super.apply(this, arguments) || this;
    }
    NotificationObserver.initWithCallback = function (onReceiveCallback) {
        var observer = _super.new.call(this);
        observer._onReceiveCallback = onReceiveCallback;
        return observer;
    };
    NotificationObserver.prototype.onReceive = function (notification) {
        this._onReceiveCallback(notification);
    };
    NotificationObserver.ObjCExposedMethods = {
        onReceive: { returns: interop.types.void, params: [NSNotification] },
    };
    return NotificationObserver;
  }(NSObject));

  const observer = NotificationObserver.initWithCallback(notification => {
  });

  NSNotificationCenter.defaultCenter.addObserverSelectorNameObject(observer, "onReceive", "MyNotification", null);

  postMessage(self === global);`;

worker.postMessage({ eval: workerScript });
```