### PR TITLE
fix: Do not update in-place object prototypes (#67)

### DIFF
--- a/NativeScript/runtime/ArgConverter.h
+++ b/NativeScript/runtime/ArgConverter.h
@@ -31,8 +31,8 @@ class ArgConverter {
 public:
     static void Init(v8::Local<v8::Context> context, v8::GenericNamedPropertyGetterCallback structPropertyGetter, v8::GenericNamedPropertySetterCallback structPropertySetter);
     static v8::Local<v8::Value> Invoke(v8::Local<v8::Context> context, Class klass, v8::Local<v8::Object> receiver, V8Args& args, const MethodMeta* meta, bool isMethodCallback);
-    static v8::Local<v8::Value> ConvertArgument(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, bool skipGCRegistration = false);
-    static v8::Local<v8::Value> CreateJsWrapper(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, v8::Local<v8::Object> receiver, bool skipGCRegistration = false);
+    static v8::Local<v8::Value> ConvertArgument(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, bool skipGCRegistration = false, const std::vector<std::string>& additionalProtocols = std::vector<std::string>());
+    static v8::Local<v8::Value> CreateJsWrapper(v8::Local<v8::Context> context, BaseDataWrapper* wrapper, v8::Local<v8::Object> receiver, bool skipGCRegistration = false, const std::vector<std::string>& additionalProtocols = std::vector<std::string>());
     static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyObject(v8::Local<v8::Context> context, bool skipGCRegistration = false);
     static std::shared_ptr<v8::Persistent<v8::Value>> CreateEmptyStruct(v8::Local<v8::Context> context);
     static const Meta* FindMeta(Class klass, const TypeEncoding* typeEncoding = nullptr);

--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -2,6 +2,7 @@
 #define Caches_h
 
 #include <string>
+#include <vector>
 #include "ConcurrentMap.h"
 #include "robin_hood.h"
 #include "Common.h"
@@ -70,7 +71,7 @@ public:
     robin_hood::unordered_map<std::pair<void*, std::string>, std::shared_ptr<v8::Persistent<v8::Value>>, pair_hash> StructInstances;
     robin_hood::unordered_map<const void*, std::shared_ptr<v8::Persistent<v8::Object>>> PointerInstances;
 
-    std::function<v8::Local<v8::FunctionTemplate>(v8::Local<v8::Context>, const BaseClassMeta*, KnownUnknownClassPair)> ObjectCtorInitializer;
+    std::function<v8::Local<v8::FunctionTemplate>(v8::Local<v8::Context>, const BaseClassMeta*, KnownUnknownClassPair, const std::vector<std::string>&)> ObjectCtorInitializer;
     std::function<v8::Local<v8::Function>(v8::Local<v8::Context>, StructInfo)> StructCtorInitializer;
     robin_hood::unordered_map<std::string, double> Timers;
     robin_hood::unordered_map<const InterfaceMeta*, std::vector<const MethodMeta*>> Initializers;

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -139,7 +139,7 @@ private:
     static v8::Local<v8::Value> CallFunctionInternal(MethodCall& methodCall);
     static bool IsNumbericType(BinaryTypeEncodingType type);
     static v8::Local<v8::Object> GetInteropType(v8::Local<v8::Context> context, BinaryTypeEncodingType type);
-    static void AttachProtocols(v8::Local<v8::Context> context, v8::Local<v8::Object> instance, PtrTo<Array<PtrTo<char>>> protocols, KnownUnknownClassPair pair);
+    static std::vector<std::string> GetAdditionalProtocols(const TypeEncoding* typeEncoding);
 
     template <typename T>
     static inline void SetValue(void* dest, T value) {

--- a/NativeScript/runtime/MetadataBuilder.h
+++ b/NativeScript/runtime/MetadataBuilder.h
@@ -13,12 +13,12 @@ namespace tns {
 class MetadataBuilder {
 public:
     static void RegisterConstantsOnGlobalObject(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate, bool isWorkerThread);
-    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplate(v8::Local<v8::Context> context, const BaseClassMeta* meta, KnownUnknownClassPair pair);
+    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplate(v8::Local<v8::Context> context, const BaseClassMeta* meta, KnownUnknownClassPair pair, const std::vector<std::string>& additionalProtocols = std::vector<std::string>());
     static v8::Local<v8::Function> GetOrCreateStructCtorFunction(v8::Local<v8::Context> context, StructInfo structInfo);
     static void StructPropertyGetterCallback(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void StructPropertySetterCallback(v8::Local<v8::Name> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
 private:
-    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplateInternal(v8::Local<v8::Context> context, const BaseClassMeta* meta, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& instanceMembers, robin_hood::unordered_map<std::string, uint8_t>& staticMembers);
+    static v8::Local<v8::FunctionTemplate> GetOrCreateConstructorFunctionTemplateInternal(v8::Local<v8::Context> context, const BaseClassMeta* meta, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& instanceMembers, robin_hood::unordered_map<std::string, uint8_t>& staticMembers, const std::vector<std::string>& additionalProtocols = std::vector<std::string>());
     static void GlobalPropertyGetter(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void AllocCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -38,6 +38,7 @@ private:
     static void RegisterInstanceMethods(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void RegisterInstanceProperties(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void RegisterInstanceProtocols(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, const BaseClassMeta* meta, std::string className, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);
+    static void RegisterAdditionalProtocols(v8::Local<v8::Context> context, v8::Local<v8::FunctionTemplate> ctorFuncTemplate, KnownUnknownClassPair pair, const std::vector<std::string>& additionalProtocols, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void RegisterStaticMethods(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void RegisterStaticProperties(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);
     static void RegisterStaticProtocols(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc, const BaseClassMeta* meta, const std::string className, KnownUnknownClassPair pair, robin_hood::unordered_map<std::string, uint8_t>& names);

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -493,6 +493,14 @@ void MetadataBuilder::RegisterAdditionalProtocols(Local<Context> context, Local<
             const BaseClassMeta* baseMeta = static_cast<const BaseClassMeta*>(meta);
             MetadataBuilder::RegisterInstanceMethods(context, ctorFuncTemplate, baseMeta, pair, names);
             MetadataBuilder::RegisterInstanceProperties(context, ctorFuncTemplate, baseMeta, baseMeta->name(), pair, names);
+
+            std::vector<std::string> metaProtocols;
+            for (auto it = baseMeta->protocols->begin(); it != baseMeta->protocols->end(); it++) {
+                std::string name = (*it).valuePtr();
+                metaProtocols.push_back(name);
+            }
+
+            MetadataBuilder::RegisterAdditionalProtocols(context, ctorFuncTemplate, pair, metaProtocols, names);
         }
     }
 }

--- a/TestFixtures/Api/TNSPseudoDataTypes.h
+++ b/TestFixtures/Api/TNSPseudoDataTypes.h
@@ -2,12 +2,14 @@
 
 @protocol Proto1
 
+@property (nonatomic) NSString* propertyFromProto1;
 -(void)methodFromProto1;
 
 @end
 
 @protocol Proto2
 
+@property (nonatomic) NSString* propertyFromProto2;
 -(void)methodFromProto2:(NSString*)param;
 
 @end

--- a/TestFixtures/Api/TNSPseudoDataTypes.m
+++ b/TestFixtures/Api/TNSPseudoDataTypes.m
@@ -19,6 +19,9 @@
 
 @implementation TNSPseudoDataTypeInternal
 
+@synthesize propertyFromProto1;
+@synthesize propertyFromProto2;
+
 -(void)methodFromProto1 {
     TNSLog(@"methodFromProto1 called");
 }
@@ -33,11 +36,15 @@
 
 +(id<Proto1, Proto2>)getId {
     TNSPseudoDataTypeInternal* internal = [[TNSPseudoDataTypeInternal alloc] init];
+    internal.propertyFromProto1 = @"property from proto1";
+    internal.propertyFromProto2 = @"property from proto2";
     return internal;
 }
 
 +(TNSType<Proto1, Proto2>*)getType {
     TNSPseudoDataTypeInternal* internal = [[TNSPseudoDataTypeInternal alloc] init];
+    internal.propertyFromProto1 = @"property from proto1";
+    internal.propertyFromProto2 = @"property from proto2";
     return internal;
 }
 

--- a/TestRunner/app/tests/ApiTests.js
+++ b/TestRunner/app/tests/ApiTests.js
@@ -738,34 +738,46 @@ describe(module.id, function () {
 
     it("Additional protocols should be attached to the prototype of id pseudo-types", () => {
         let actual = TNSPseudoDataType.getId();
+        expect(actual.propertyFromProto1).toBeDefined();
         expect(actual.methodFromProto1).toBeDefined();
+        expect(actual.propertyFromProto2).toBeDefined();
         expect(actual.methodFromProto2).toBeDefined();
 
+        expect(actual.propertyFromProto1).toBe("property from proto1");
         actual.methodFromProto1();
+        expect(actual.propertyFromProto2).toBe("property from proto2");
         actual.methodFromProto2("test");
 
         expect(TNSGetOutput()).toBe("methodFromProto1 calledmethodFromProto2 called with test");
 
         let obj = NSObject.alloc().init();
+        expect(obj.propertyFromProto1).toBeUndefined();
         expect(obj.methodFromProto1).toBeUndefined();
+        expect(obj.propertyFromProto2).toBeUndefined();
         expect(obj.methodFromProto2).toBeUndefined();
     });
 
     it("Additional protocols should be attached to the prototype of interface pseudo-types", () => {
         let actual = TNSPseudoDataType.getType();
         expect(actual.method).toBeDefined();
-        expect(actual.methodFromProto2).toBeDefined();
+        expect(actual.propertyFromProto1).toBeDefined();
+        expect(actual.methodFromProto1).toBeDefined();
+        expect(actual.propertyFromProto2).toBeDefined();
         expect(actual.methodFromProto2).toBeDefined();
 
         actual.method();
+        expect(actual.propertyFromProto1).toBe("property from proto1");
         actual.methodFromProto1();
+        expect(actual.propertyFromProto2).toBe("property from proto2");
         actual.methodFromProto2("test");
 
         expect(TNSGetOutput()).toBe("method calledmethodFromProto1 calledmethodFromProto2 called with test");
 
         let obj = NSObject.alloc().init();
         expect(obj.method).toBeUndefined();
+        expect(obj.propertyFromProto1).toBeUndefined();
         expect(obj.methodFromProto1).toBeUndefined();
+        expect(obj.propertyFromProto2).toBeUndefined();
         expect(obj.methodFromProto2).toBeUndefined();
     });
 


### PR DESCRIPTION
Related to #67 

This PR addresses an issue where we replace the existing object prototype with additional protocols returned from pseudo types. Instead of modifying the prototype chain, we build an entirely new chain containing the additional protocols.