### PR TITLE
fix: create handle scope with proper isolate (#77)

### DIFF
--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -41,9 +41,8 @@ Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
                 Isolate::Scope isolate_scope(runtimeIsolate);
                 HandleScope handle_scope(runtimeIsolate);
                 Local<Value> callback = wrapper->callback_->Get(runtimeIsolate);
-                if (!callback.IsEmpty() && callback->IsObject()) {
-                    Local<Context> context = callback.As<Object>()->CreationContext();
-                    Isolate* isolate = context->GetIsolate();
+                Isolate* isolate = wrapper->isolate_;
+                if (Runtime::IsAlive(isolate) && !callback.IsEmpty() && callback->IsObject()) {
                     v8::Locker locker(isolate);
                     Isolate::Scope isolate_scope(isolate);
                     HandleScope handle_scope(isolate);


### PR DESCRIPTION
Related to #77 

- Use proper isolate when creating the handle scope in the block destructor