### PR TITLE
fix: DictionaryAdapter missing handle scopes and locks

### DIFF
--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -34,6 +34,10 @@ using namespace tns;
 
 - (id)nextObject {
     Isolate* isolate = self->isolate_;
+    v8::Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+
     Local<Context> context = self->cache_->GetContext();
     Local<v8::Array> array = self->map_->Get(isolate).As<Map>()->AsArray();
 
@@ -82,15 +86,23 @@ using namespace tns;
 }
 
 - (Local<v8::Array>)getProperties {
+    v8::Locker locker(self->isolate_);
+    Isolate::Scope isolate_scope(self->isolate_);
+    EscapableHandleScope handle_scope(self->isolate_);
+
     Local<Context> context = self->cache_->GetContext();
     Local<v8::Array> properties;
     Local<Object> dictionary = self->dictionary_->Get(self->isolate_).As<Object>();
     tns::Assert(dictionary->GetOwnPropertyNames(context).ToLocal(&properties), self->isolate_);
-    return properties;
+    return handle_scope.Escape(properties);
 }
 
 - (id)nextObject {
     Isolate* isolate = self->isolate_;
+    v8::Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+
     Local<Context> context = self->cache_->GetContext();
     Local<v8::Array> properties = [self getProperties];
     if (self->index_ < properties->Length()) {
@@ -107,6 +119,10 @@ using namespace tns;
 
 - (NSArray*)allObjects {
     Isolate* isolate = self->isolate_;
+    v8::Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+
     Local<Context> context = self->cache_->GetContext();
     NSMutableArray* array = [NSMutableArray array];
     Local<v8::Array> properties = [self getProperties];
@@ -146,6 +162,10 @@ using namespace tns;
 }
 
 - (NSUInteger)count {
+    v8::Locker locker(self->isolate_);
+    Isolate::Scope isolate_scope(self->isolate_);
+    HandleScope handle_scope(self->isolate_);
+
     Local<Object> obj = self->object_->Get(self->isolate_).As<Object>();
 
     if (obj->IsMap()) {
@@ -163,6 +183,10 @@ using namespace tns;
 
 - (id)objectForKey:(id)aKey {
     Isolate* isolate = self->isolate_;
+    v8::Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+
     Local<Context> context = self->cache_->GetContext();
     Local<Object> obj = self->object_->Get(self->isolate_).As<Object>();
 
@@ -194,6 +218,10 @@ using namespace tns;
 }
 
 - (NSEnumerator*)keyEnumerator {
+    v8::Locker locker(self->isolate_);
+    Isolate::Scope isolate_scope(self->isolate_);
+    HandleScope handle_scope(self->isolate_);
+
     Local<Value> obj = self->object_->Get(self->isolate_);
 
     if (obj->IsMap()) {

--- a/NativeScript/runtime/PromiseProxy.cpp
+++ b/NativeScript/runtime/PromiseProxy.cpp
@@ -28,14 +28,14 @@ void PromiseProxy::Init(v8::Local<v8::Context> context) {
                     return new Proxy(promise, {
                         get: function(target, name) {
                             let orig = target[name];
-                            if (name === "then" || name === "catch") {
+                            if (name === "then" || name === "catch" || name === "finally") {
                                 return orig.bind(target);
                             }
-                            return function(x) {
+                            return typeof orig === 'function' ? function(x) {
                                 CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, orig.bind(target, x));
                                 CFRunLoopWakeUp(runloop);
                                 return target;
-                            };
+                            } : orig;
                         }
                     });
                 }


### PR DESCRIPTION
Fixes https://github.com/EddyVerbruggen/nativescript-plugin-firebase/issues/1728, which seems to have been due to thread switching in the callback at [FIRFunctions.m#L187](https://github.com/firebase/firebase-ios-sdk/blob/62735099d51778e43f15adc8f0057b7c8d72e17b/Functions/FirebaseFunctions/FIRFunctions.m#L187). This issue will affect any native library functions called with a JavaScript object which are then wrapped in a DictionaryAdapter, and then attempt to access or enumerate the DictionaryAdapters contents from another thread.

I have not worked in Objective C nor with V8 internals before. This pull request needs a careful review and testing. Thank you @darind for pointing me in the right direction.