### PR TITLE
fix(xcode): 12.3 support

### DIFF
--- a/project-template/internal/nativescript-build.xcconfig
+++ b/project-template/internal/nativescript-build.xcconfig
@@ -22,3 +22,4 @@ LDPLUSPLUS = $SRCROOT/internal/nsld.sh
 EXCLUDED_ARCHS_x86_64 = arm64 arm64e
 EXCLUDED_ARCHS[sdk=iphonesimulator*] = i386 armv6 armv7 armv7s armv8 $(EXCLUDED_ARCHS_$(NATIVE_ARCH_64_BIT))
 EXCLUDED_ARCHS[sdk=iphoneos*] = i386 armv6 armv7 armv7s armv8 x86_64
+VALIDATE_WORKSPACE = YES


### PR DESCRIPTION
https://github.com/NativeScript/ios-runtime/pull/1289/files

Xcode 12.3 builds succeed when VALIDATE_WORKSPACE is explicitly set to YES.