### PR TITLE
fix: PromiseProxy returns function regardless of underlying property type

### DIFF
--- a/NativeScript/runtime/PromiseProxy.cpp
+++ b/NativeScript/runtime/PromiseProxy.cpp
@@ -28,14 +28,14 @@ void PromiseProxy::Init(v8::Local<v8::Context> context) {
                     return new Proxy(promise, {
                         get: function(target, name) {
                             let orig = target[name];
-                            if (name === "then" || name === "catch") {
+                            if (name === "then" || name === "catch" || name === "finally") {
                                 return orig.bind(target);
                             }
-                            return function(x) {
+                            return typeof orig === 'function' ? function(x) {
                                 CFRunLoopPerformBlock(runloop, kCFRunLoopDefaultMode, orig.bind(target, x));
                                 CFRunLoopWakeUp(runloop);
                                 return target;
-                            };
+                            } : orig;
                         }
                     });
                 }


### PR DESCRIPTION
The current wrapper causes accesses to any property of a promise object to return a function, even when the actual value on the target proxy is not a function.

I don't understand why it's only for properties **other than** .then/.catch that the proxy trap interferes and makes sure the function executes on the same thread as the Promise was created, but I'll leave that for someone else to look into.
