### PR TITLE
DictionaryAdapter Hanging References

### DIFF
--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -249,7 +249,7 @@ using namespace tns;
     }
     self->object_->Reset();
     
-    self->isolate_ = nil;
+    self->isolate_ = nullptr;
     self->cache_ = nil;
     self->object_ = nil;
     [super dealloc];

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -55,6 +55,10 @@ using namespace tns;
 }
 
 - (void)dealloc {
+    self->isolate_ = nullptr;
+    self->map_ = nil;
+    self->cache_ = nil;
+    
     [super dealloc];
 }
 
@@ -138,6 +142,10 @@ using namespace tns;
 }
 
 - (void)dealloc {
+    self->isolate_ = nullptr;
+    self->dictionary_ = nil;
+    self->cache_ = nil;
+    
     [super dealloc];
 }
 
@@ -240,6 +248,10 @@ using namespace tns;
         delete wrapper;
     }
     self->object_->Reset();
+    
+    self->isolate_ = nil;
+    self->cache_ = nil;
+    self->object_ = nil;
     [super dealloc];
 }
 


### PR DESCRIPTION
DictionaryAdapter is leaking memory when objects are deallocated.

This PR serves to clean up some hanging references. In my test case this reduced the total leaks caused by DictionaryAdapter by 36%.