### PR TITLE
chore: Add step to fix attaching to real device

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Remove the `NativeScript.xcframework` from the General tab, as we will no longer
 
 <img width="693" alt="Screenshot 2020-09-09 at 18 47 23" src="https://user-images.githubusercontent.com/879060/92628311-e6f09c80-f2cc-11ea-8977-201517badc3b.png">
 
+Add the `Nativescript.framework` from the v8ios workspace:
+
+<img width="402" alt="Screen Shot 2021-04-12 at 11 49 10 AM" src="https://user-images.githubusercontent.com/2379994/114423589-51c8c580-9b85-11eb-9d30-eb1cbf73454a.png">
+
+
 Hitting Run in XCode should start the app in the simulator, and we can now add breakpoints to the runtime and step through it with the debugger. To apply changes to the javascript, make sure you run `ns prepare ios` to re-bundle it into the `platforms/ios` folder.
 
 # Overview

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Remove the `NativeScript.xcframework` from the General tab, as we will no longer
 
 <img width="693" alt="Screenshot 2020-09-09 at 18 47 23" src="https://user-images.githubusercontent.com/879060/92628311-e6f09c80-f2cc-11ea-8977-201517badc3b.png">
 
-Add the `Nativescript.framework` from the v8ios workspace:
+Add the `Nativescript.framework` from the v8ios workspace (only required when running on a physical device):
 
 <img width="402" alt="Screen Shot 2021-04-12 at 11 49 10 AM" src="https://user-images.githubusercontent.com/2379994/114423589-51c8c580-9b85-11eb-9d30-eb1cbf73454a.png">
 


### PR DESCRIPTION
The current README for attaching the runtime to an existing project works only if you are using a simulator to debug.  For some reason when using a real device Xcode requires you to explicitly add `Nativescript.framework` on the General Tab.