### PR TITLE
fix: handle methods with pointer type params

### DIFF
--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -466,6 +466,8 @@ BinaryTypeEncodingType ClassBuilder::GetTypeEncodingType(Isolate* isolate, Local
             return pdw->TypeEncoding()->type;
         } else if (wrapper->Type() == WrapperType::ObjCObject) {
             return BinaryTypeEncodingType::IdEncoding;
+        } else if (wrapper->Type() == WrapperType::PointerType) {
+            return BinaryTypeEncodingType::PointerEncoding;
         }
     }
 


### PR DESCRIPTION
fixes #109.

I was having the same issue as #109 when trying to fix a call to `UISaveVideoAtPathToSavedPhotosAlbum`.  It turns out the runtime would throw an error as soon as you added a method that had a parameter of type interop.Pointer to the ObjCExposedMethods object because GetTypeEncodingType didn't know how to deal with it.

This change also helps fix some of the underlying issues in https://github.com/nstudio/nativescript-plugins/issues/12