### PR TITLE
fix: Take into account null terminated C strings (#131)

### DIFF
--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -174,7 +174,8 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
             } else {
                 v8::String::Utf8Value utf8Value(isolate, arg);
                 value = strdup(*utf8Value);
-                OneByteStringResource* resource = new OneByteStringResource(value, strArg->Length());
+                auto length = strArg->Length() + 1;
+                OneByteStringResource* resource = new OneByteStringResource(value, length);
                 bool success = v8::String::NewExternalOneByte(isolate, resource).ToLocal(&arg);
                 tns::Assert(success, isolate);
             }


### PR DESCRIPTION
- Take into account null terminated C strings when marshalling parameters to native functions

Related to #131 