### PR TITLE
fix: prevent crashes during onuncaughterror

### DIFF
--- a/NativeScript/runtime/NativeScriptException.mm
+++ b/NativeScript/runtime/NativeScriptException.mm
@@ -43,7 +43,12 @@ void NativeScriptException::OnUncaughtError(Local<Message> message, Local<Value>
         Local<Object> thiz = Object::New(isolate);
         Local<Value> args[] = { error };
         Local<Value> result;
+        TryCatch tc(isolate);
         success = errorHandlerFunc->Call(context, thiz, 1, args).ToLocal(&result);
+        if (tc.HasCaught()) {
+            tns::LogError(isolate, tc);
+        }
+
         tns::Assert(success, isolate);
     }
 

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -158,10 +158,10 @@ id Runtime::GetAppConfigValue(std::string key) {
     if (AppPackageJson == nil) {
         NSString* packageJsonPath = [[NSString stringWithUTF8String:RuntimeConfig.ApplicationPath.c_str()] stringByAppendingPathComponent:@"package.json"];
         NSData* data = [NSData dataWithContentsOfFile:packageJsonPath];
-        AppPackageJson = @{};
         if (data) {
             NSError* error = nil;
-            AppPackageJson = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+            NSDictionary* dict = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];
+            AppPackageJson = [[NSDictionary alloc] initWithDictionary:dict];
         }
     }
 


### PR DESCRIPTION
This PR aims to address some unwanted crashes that would happen during the `OnUncaughtError` handler.

The first relates to how the `AppPackageJson` file was being read to fetch the `discardUncaughtJsExceptions` flag. The NSJSONSerialization would produce a NSDictionary that would get autoreleased. On subsequent calls to `OnUncaughtError`, the `AppPackageJson` pointer would be cleared causing a bad access.

To address this, I alloc and init a new NSDictionary from the serialization so that this dictionary will not get released between calls to `OnUncaughtError`. I'm not super familiar with Objective-C or how this runtime is setup, so I don't know if there is a point where we _should_ manually release this dictionary. Please let me know if this should be handled.

Second, I ran into an unhelpful stack trace when trying to test the error events I setup and eventually realized that my event handlers were also causing a javascript exception, but since we were already in the `OnUncaughtError` method, the `tns::Assert` would be false and quit the app. I addressed this by using `TryCatch` and logging the caught error so developers have visibility on if their error event handlers are also causing an error.

This PR will most likely close #126 and possibly is related to some crashes other users have reported.