### PR TITLE
fix: TypeEncoding might be initialized with random data

### DIFF
--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -547,8 +547,7 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
             std::string methodNameStr = tns::ToString(isolate, methodName);
             SEL selector = sel_registerName(methodNameStr.c_str());
 
-            TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(malloc((argsCount + 1) * sizeof(TypeEncoding)));
-            memset(typeEncoding, 0, (argsCount + 1) * sizeof(TypeEncoding));
+            TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(calloc((argsCount + 1), sizeof(TypeEncoding)));
             typeEncoding->type = returnType;
 
             if (!paramsVal.IsEmpty() && paramsVal->IsArray()) {

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -548,6 +548,7 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
             SEL selector = sel_registerName(methodNameStr.c_str());
 
             TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(malloc((argsCount + 1) * sizeof(TypeEncoding)));
+            memset(typeEncoding, 0, (argsCount + 1) * sizeof(TypeEncoding));
             typeEncoding->type = returnType;
 
             if (!paramsVal.IsEmpty() && paramsVal->IsArray()) {

--- a/NativeScript/runtime/InteropTypes.mm
+++ b/NativeScript/runtime/InteropTypes.mm
@@ -309,8 +309,7 @@ void Interop::RegisterSizeOfFunction(Local<Context> context, Local<Object> inter
 }
 
 const TypeEncoding* Interop::CreateEncoding(BinaryTypeEncodingType type) {
-    TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(malloc(sizeof(TypeEncoding)));
-    memset(typeEncoding, 0, sizeof(TypeEncoding));
+    TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(calloc(1, sizeof(TypeEncoding)));
     typeEncoding->type = type;
 
     return typeEncoding;

--- a/NativeScript/runtime/InteropTypes.mm
+++ b/NativeScript/runtime/InteropTypes.mm
@@ -310,6 +310,7 @@ void Interop::RegisterSizeOfFunction(Local<Context> context, Local<Object> inter
 
 const TypeEncoding* Interop::CreateEncoding(BinaryTypeEncodingType type) {
     TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(malloc(sizeof(TypeEncoding)));
+    memset(typeEncoding, 0, sizeof(TypeEncoding));
     typeEncoding->type = type;
 
     return typeEncoding;


### PR DESCRIPTION
I don't believe this is the definite fix. The correct fix would be for each TypeEncoding type to initialize it's own struct with the proper values instead of relying on them to be "0" or "nil".

Other places that use `PtrTo<>` should be investigated as well as they might contain garbage data ocasionally