### PR TITLE
fix: lock isolate before handle_scope

### DIFF
--- a/NativeScript/inspector/JsV8InspectorClient.mm
+++ b/NativeScript/inspector/JsV8InspectorClient.mm
@@ -252,6 +252,7 @@ inline Local<TypeName> JsV8InspectorClient::PersistentToLocal(Isolate* isolate, 
 
 void JsV8InspectorClient::scheduleBreak() {
     Isolate* isolate = runtime_->GetIsolate();
+    v8::Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     this->session_->schedulePauseOnNextStatement(StringView(), StringView());


### PR DESCRIPTION
this fixes a bug where we don't lock the isolate before calling handle_scope, which might make v8 crash.

This crash always happens if you use --debug-brk and try to attach the dev tools