### PR TITLE
feat: add support for reasons on assertion failure

### DIFF
--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -65,7 +65,7 @@ const std::string GetCurrentScriptUrl(v8::Isolate* isolate);
 
 bool LiveSync(v8::Isolate* isolate);
 
-void Assert(bool condition, v8::Isolate* isolate = nullptr);
+void Assert(bool condition, v8::Isolate* isolate = nullptr, std::string const &reason = std::string());
 
 }
 

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -657,7 +657,7 @@ bool tns::LiveSync(Isolate* isolate) {
     return true;
 }
 
-void tns::Assert(bool condition, Isolate* isolate) {
+void tns::Assert(bool condition, Isolate* isolate, std::string const &reason) {
     if (!RuntimeConfig.IsDebug) {
         assert(condition);
         return;
@@ -676,6 +676,9 @@ void tns::Assert(bool condition, Isolate* isolate) {
 
     if (isolate == nullptr) {
         Log(@"====== Assertion failed ======");
+        if(!reason.empty()) {
+            Log(@"Reason: %s", reason.c_str());
+        }
         Log(@"Native stack trace:");
         LogBacktrace();
         assert(false);


### PR DESCRIPTION
The actual reasons still need to be added, but this should be enough to slowly start adding information to the magical "assertion failed" errors with no description of what failed and why