### PR TITLE
perf: cache swizzled selector construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ v8
 .npmrc
 
 llvm/
+
+# v8 build files...
+.gclient_entries
+.gclient
+.cipd/

--- a/NativeScript/NativeScript-Prefix.pch
+++ b/NativeScript/NativeScript-Prefix.pch
@@ -1,7 +1,7 @@
 #ifndef NativeScript_Prefix_pch
 #define NativeScript_Prefix_pch
 
-#define NATIVESCRIPT_VERSION "8.3.1-alpha.0"
+#define NATIVESCRIPT_VERSION "8.3.1-alpha.1"
 
 #ifdef DEBUG
 #define SIZEOF_OFF_T 8

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -37,11 +37,25 @@ BaseDataWrapper* GetValue(v8::Isolate* isolate, const v8::Local<v8::Value>& val)
 void DeleteValue(v8::Isolate* isolate, const v8::Local<v8::Value>& val);
 std::vector<v8::Local<v8::Value>> ArgsToVector(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-bool IsString(v8::Local<v8::Value> value);
-bool IsNumber(v8::Local<v8::Value> value);
-bool IsBool(v8::Local<v8::Value> value);
-bool IsArrayOrArrayLike(v8::Isolate* isolate, v8::Local<v8::Value> value);
-void* TryGetBufferFromArrayBuffer(v8::Local<v8::Value> value, bool& isArrayBuffer);
+//bool IsString(const v8::Local<v8::Value>& value);
+//bool IsNumber(const v8::Local<v8::Value>& value);
+//bool IsBool(const v8::Local<v8::Value>& value);
+
+inline bool IsString(const v8::Local<v8::Value>& value) {
+    return !value.IsEmpty() && (value->IsString() || value->IsStringObject());
+}
+
+inline bool IsNumber(const v8::Local<v8::Value>& value) {
+    return !value.IsEmpty() && (value->IsNumber() || value->IsNumberObject());
+}
+
+inline bool IsBool(const v8::Local<v8::Value>& value) {
+    return !value.IsEmpty() && (value->IsBoolean() || value->IsBooleanObject());
+}
+
+
+bool IsArrayOrArrayLike(v8::Isolate* isolate, const v8::Local<v8::Value>& value);
+void* TryGetBufferFromArrayBuffer(const v8::Local<v8::Value>& value, bool& isArrayBuffer);
 
 void ExecuteOnMainThread(std::function<void ()> func, bool async = true);
 

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -37,10 +37,6 @@ BaseDataWrapper* GetValue(v8::Isolate* isolate, const v8::Local<v8::Value>& val)
 void DeleteValue(v8::Isolate* isolate, const v8::Local<v8::Value>& val);
 std::vector<v8::Local<v8::Value>> ArgsToVector(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-//bool IsString(const v8::Local<v8::Value>& value);
-//bool IsNumber(const v8::Local<v8::Value>& value);
-//bool IsBool(const v8::Local<v8::Value>& value);
-
 inline bool IsString(const v8::Local<v8::Value>& value) {
     return !value.IsEmpty() && (value->IsString() || value->IsStringObject());
 }

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -336,20 +336,20 @@ std::vector<Local<Value>> tns::ArgsToVector(const FunctionCallbackInfo<Value>& i
     }
     return args;
 }
-
-bool tns::IsString(Local<Value> value) {
-    return !value.IsEmpty() && (value->IsString() || value->IsStringObject());
-}
-
-bool tns::IsNumber(Local<Value> value) {
-    return !value.IsEmpty() && (value->IsNumber() || value->IsNumberObject());
-}
-
-bool tns::IsBool(Local<Value> value) {
-    return !value.IsEmpty() && (value->IsBoolean() || value->IsBooleanObject());
-}
-
-bool tns::IsArrayOrArrayLike(Isolate* isolate, Local<Value> value) {
+//
+//bool tns::IsString(const Local<Value>& value) {
+//    return !value.IsEmpty() && (value->IsString() || value->IsStringObject());
+//}
+//
+//bool tns::IsNumber(const Local<Value>& value) {
+//    return !value.IsEmpty() && (value->IsNumber() || value->IsNumberObject());
+//}
+//
+//bool tns::IsBool(const Local<Value>& value) {
+//    return !value.IsEmpty() && (value->IsBoolean() || value->IsBooleanObject());
+//}
+//
+bool tns::IsArrayOrArrayLike(Isolate* isolate, const Local<Value>& value) {
     if (value->IsArray()) {
         return true;
     }
@@ -365,7 +365,7 @@ bool tns::IsArrayOrArrayLike(Isolate* isolate, Local<Value> value) {
     return obj->Has(context, ToV8String(isolate, "length")).FromMaybe(false);
 }
 
-void* tns::TryGetBufferFromArrayBuffer(v8::Local<v8::Value> value, bool& isArrayBuffer) {
+void* tns::TryGetBufferFromArrayBuffer(const v8::Local<v8::Value>& value, bool& isArrayBuffer) {
     isArrayBuffer = false;
 
     if (value.IsEmpty() || (!value->IsArrayBuffer() && !value->IsArrayBufferView())) {

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -336,19 +336,7 @@ std::vector<Local<Value>> tns::ArgsToVector(const FunctionCallbackInfo<Value>& i
     }
     return args;
 }
-//
-//bool tns::IsString(const Local<Value>& value) {
-//    return !value.IsEmpty() && (value->IsString() || value->IsStringObject());
-//}
-//
-//bool tns::IsNumber(const Local<Value>& value) {
-//    return !value.IsEmpty() && (value->IsNumber() || value->IsNumberObject());
-//}
-//
-//bool tns::IsBool(const Local<Value>& value) {
-//    return !value.IsEmpty() && (value->IsBoolean() || value->IsBooleanObject());
-//}
-//
+
 bool tns::IsArrayOrArrayLike(Isolate* isolate, const Local<Value>& value) {
     if (value->IsArray()) {
         return true;

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -148,6 +148,7 @@ private:
     static bool IsNumbericType(BinaryTypeEncodingType type);
     static v8::Local<v8::Object> GetInteropType(v8::Local<v8::Context> context, BinaryTypeEncodingType type);
     static std::vector<std::string> GetAdditionalProtocols(const TypeEncoding* typeEncoding);
+    static SEL GetSwizzledMethodSelector(SEL selector);
 
     template <typename T>
     static inline void SetValue(void* dest, T value) {
@@ -192,6 +193,7 @@ private:
         
         static JSBlockDescriptor kJSBlockDescriptor;
     } JSBlock;
+    
 };
 
 }

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1394,12 +1394,14 @@ SEL Interop::GetSwizzledMethodSelector(SEL selector) {
 //    swizzledMethodSelector = static_cast<SEL>([[swizzledMethodSelectorCache objectForKey:key] pointerValue]);
     
     if(!swizzledMethodSelector) {
-        NSString* selectorStr = NSStringFromSelector(selector);
-        NSString* swizzledMethodSelectorStr;
-        // todo: replace with faster string concat if that makes an impact...
-        swizzledMethodSelectorStr = [NSString stringWithFormat:@"%s%@", Constants::SwizzledPrefix.c_str(), selectorStr];
+        swizzledMethodSelector = sel_registerName((Constants::SwizzledPrefix + std::string(sel_getName(selector))).c_str());
         
-        swizzledMethodSelector = NSSelectorFromString(swizzledMethodSelectorStr);
+//        NSString* selectorStr = NSStringFromSelector(selector);
+//        NSString* swizzledMethodSelectorStr;
+        // todo: replace with faster string concat if that makes an impact...
+//        swizzledMethodSelectorStr = [NSString stringWithFormat:@"%s%@", Constants::SwizzledPrefix.c_str(), selectorStr];
+        
+//        swizzledMethodSelector = NSSelectorFromString(swizzledMethodSelectorStr);
         
         // save to cache
         swizzledMethodSelectorCache->emplace(selector, swizzledMethodSelector);

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -18,6 +18,7 @@
 #include "SymbolIterator.h"
 #include "UnmanagedType.h"
 #include "OneByteStringResource.h"
+#include "robin_hood.h"
 
 using namespace v8;
 
@@ -1376,7 +1377,9 @@ SEL Interop::GetSwizzledMethodSelector(SEL selector) {
         return swizzledMethodSelector;
     }
     
-    static std::map<SEL, SEL> *swizzledMethodSelectorCache = new std::map<SEL, SEL>();
+    static robin_hood::unordered_map<SEL, SEL> *swizzledMethodSelectorCache = new robin_hood::unordered_map<SEL, SEL>();
+    
+//    static std::map<SEL, SEL> *swizzledMethodSelectorCache = new std::map<SEL, SEL>();
     
 //    static NSMutableDictionary<NSValue*, NSValue*> *swizzledMethodSelectorCache = [[NSMutableDictionary alloc] init];
     

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1368,22 +1368,8 @@ Local<v8::Array> Interop::ToArray(Local<Object> object) {
 }
 
 SEL Interop::GetSwizzledMethodSelector(SEL selector) {
-    if(/* DISABLES CODE */ (false)) {
-        // old impl
-        NSString* selectorStr = NSStringFromSelector(selector);
-        NSString* swizzledMethodSelectorStr = [NSString stringWithFormat:@"%s%@", Constants::SwizzledPrefix.c_str(), selectorStr];
-        SEL swizzledMethodSelector = NSSelectorFromString(swizzledMethodSelectorStr);
-            
-        return swizzledMethodSelector;
-    }
-    
     static robin_hood::unordered_map<SEL, SEL> *swizzledMethodSelectorCache = new robin_hood::unordered_map<SEL, SEL>();
-    
-//    static std::map<SEL, SEL> *swizzledMethodSelectorCache = new std::map<SEL, SEL>();
-    
-//    static NSMutableDictionary<NSValue*, NSValue*> *swizzledMethodSelectorCache = [[NSMutableDictionary alloc] init];
-    
-//    auto key = [NSValue valueWithPointer:selector];
+
     SEL swizzledMethodSelector = NULL;
     
     try {
@@ -1391,41 +1377,14 @@ SEL Interop::GetSwizzledMethodSelector(SEL selector) {
     } catch(const std::out_of_range&) {
         // ignore...
     }
-//    swizzledMethodSelector = static_cast<SEL>([[swizzledMethodSelectorCache objectForKey:key] pointerValue]);
-    
+
     if(!swizzledMethodSelector) {
         swizzledMethodSelector = sel_registerName((Constants::SwizzledPrefix + std::string(sel_getName(selector))).c_str());
-        
-//        NSString* selectorStr = NSStringFromSelector(selector);
-//        NSString* swizzledMethodSelectorStr;
-        // todo: replace with faster string concat if that makes an impact...
-//        swizzledMethodSelectorStr = [NSString stringWithFormat:@"%s%@", Constants::SwizzledPrefix.c_str(), selectorStr];
-        
-//        swizzledMethodSelector = NSSelectorFromString(swizzledMethodSelectorStr);
-        
         // save to cache
         swizzledMethodSelectorCache->emplace(selector, swizzledMethodSelector);
-//        swizzledMethodSelectorCacheAmazeballs->insert(selector, swizzledMethodSelector);
-//        [swizzledMethodSelectorCache setObject: [NSValue valueWithPointer:swizzledMethodSelector] forKey:key];
     }
     
     return swizzledMethodSelector;
-    
-// CACHE based on strings...
-//    static NSMutableDictionary<NSString *, NSString*> *cache = [[NSMutableDictionary alloc] init];
-//    NSString* selectorStr = NSStringFromSelector(selector);
-//    NSString* swizzledMethodSelectorStr;
-//
-//    swizzledMethodSelectorStr = [cache valueForKey:selectorStr];
-//
-//    if(!swizzledMethodSelectorStr) {
-//        swizzledMethodSelectorStr = [NSString stringWithFormat:@"%s%@", Constants::SwizzledPrefix.c_str(), selectorStr];
-//
-//        // save it to the cache...
-//        [cache setObject:swizzledMethodSelectorStr forKey:selectorStr];
-//    }
-//
-//    return NSSelectorFromString(swizzledMethodSelectorStr);
 }
 
 Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/ios",
   "description": "NativeScript Runtime for iOS",
-  "version": "8.3.1-alpha.0",
+  "version": "8.3.1-alpha.1",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
Checking if a swizzled method exists constructs the selector for every call by concatenating the swizzle prefix to the actual selector string. This is pretty slow when doing many calls. 

This PR keeps a map (using robin_hood::unordered_map for performance) of SEL (selector) pairs, so that the swizzled selector is only constructed once, and any subsequent calls will use the fast-path by returning the value from the cache.

From a few performance tests, we've seen a ~30% improvement, though it may vary from case to case.