### PR TITLE
fix: console prefix missing

### DIFF
--- a/NativeScript/runtime/Console.cpp
+++ b/NativeScript/runtime/Console.cpp
@@ -61,7 +61,7 @@ void Console::LogCallback(const FunctionCallbackInfo<Value>& args) {
     std::string level = VerbosityToInspectorVerbosity(verbosityLevel);
     v8_inspector::V8LogAgentImpl::EntryAdded(msgToLog, level, "", 0);
     std::string msgWithVerbosity = "CONSOLE " + verbosityLevelUpper + ": " + msgToLog;
-    Log("%s", msgToLog.c_str());
+    Log("%s", msgWithVerbosity.c_str());
 }
 
 void Console::AssertCallback(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
removed in fea46b282213e6557a0f0b80322b1694104676c1 then partially restored in 19d56eb55f4e0ce8756b2ba63c8f2ddae2a84943

