### PR TITLE
fix(metadata-generator): skip empty bitfields

### DIFF
--- a/metadata-generator/src/TypeScript/DefinitionWriter.cpp
+++ b/metadata-generator/src/TypeScript/DefinitionWriter.cpp
@@ -654,6 +654,11 @@ std::string DefinitionWriter::writeProperty(PropertyMeta* meta, BaseClassMeta* o
         return std::string();
     }
 
+    // prevent writing out empty property names
+    if (meta->jsName.length() == 0) {
+        return std::string();
+    }
+
     output << meta->jsName;
     if (owner->is(MetaType::Protocol) && clang::dyn_cast<clang::ObjCPropertyDecl>(meta->declaration)->getPropertyImplementation() == clang::ObjCPropertyDecl::PropertyControl::Optional) {
         output << "?";
@@ -751,6 +756,13 @@ void DefinitionWriter::writeMembers(const std::vector<RecordField>& fields, std:
         if (i < fieldsComments.size()) {
             _buffer << fieldsComments[i].toString("\t");
         }
+
+        // prevent writing empty field names,
+        // fixes issue with structs containing emtpy bitfields (ie. __darwin_fp_control)
+        if(fields[i].name.length() == 0) {
+            continue;
+        }
+
         _buffer << "\t" << fields[i].name << ": " << tsifyType(*fields[i].encoding) << ";" << std::endl;
     }
 }


### PR DESCRIPTION
before:
```ts
interface __darwin_fp_control {
	__invalid: number;
	__denorm: number;
	__zdiv: number;
	__ovrfl: number;
	__undfl: number;
	__precis: number;
	: number;
	__pc: number;
	__rc: number;
	: number;
	: number;
}
```

after:
```ts
interface __darwin_fp_control {
	__invalid: number;
	__denorm: number;
	__zdiv: number;
	__ovrfl: number;
	__undfl: number;
	__precis: number;
	__pc: number;
	__rc: number;
}
```