### PR TITLE
fix(ios16-beta5): errors and crash

### DIFF
--- a/NativeScript/NativeScript-Prefix.pch
+++ b/NativeScript/NativeScript-Prefix.pch
@@ -1,7 +1,7 @@
 #ifndef NativeScript_Prefix_pch
 #define NativeScript_Prefix_pch
 
-#define NATIVESCRIPT_VERSION "8.3.2"
+#define NATIVESCRIPT_VERSION "8.3.3-alpha.0"
 
 #ifdef DEBUG
 #define SIZEOF_OFF_T 8

--- a/NativeScript/runtime/ExtVector.cpp
+++ b/NativeScript/runtime/ExtVector.cpp
@@ -80,7 +80,7 @@ void ExtVector::RegisterToStringMethod(Isolate* isolate, Local<ObjectTemplate> p
         void* value = wrapper->Data();
 
         char buffer[100];
-        sprintf(buffer, "<Vector: %p>", value);
+        snprintf(buffer, 100, "<Vector: %p>", value);
 
         Local<v8::String> result = tns::ToV8String(isolate, buffer);
         info.GetReturnValue().Set(result);

--- a/NativeScript/runtime/Metadata.mm
+++ b/NativeScript/runtime/Metadata.mm
@@ -76,7 +76,12 @@ bool MethodMeta::isImplementedInClass(Class klass, bool isStatic) const {
 
         auto it = sampleInstances.find(klass);
         if (it == sampleInstances.end()) {
-            it = sampleInstances.emplace(klass, [klass alloc]).first;
+            @try {
+                it = sampleInstances.emplace(klass, [klass alloc]).first;
+            }
+            @catch(id err) {
+                return false;
+            }
         }
         id sampleInstance = it->second;
         return [sampleInstance respondsToSelector:this->selector()];

--- a/NativeScript/runtime/Pointer.cpp
+++ b/NativeScript/runtime/Pointer.cpp
@@ -179,7 +179,7 @@ void Pointer::RegisterToStringMethod(Local<Context> context, Local<Object> proto
         void* value = wrapper->Data();
 
         char buffer[100];
-        sprintf(buffer, "<Pointer: %p>", value);
+        snprintf(buffer, 100, "<Pointer: %p>", value);
 
         Local<v8::String> result = tns::ToV8String(isolate, buffer);
         info.GetReturnValue().Set(result);
@@ -200,7 +200,7 @@ void Pointer::RegisterToHexStringMethod(Local<Context> context, Local<Object> pr
         const void* value = wrapper->Data();
 
         char buffer[100];
-        sprintf(buffer, "%p", value);
+        snprintf(buffer, 100, "%p", value);
 
         Local<v8::String> result = tns::ToV8String(isolate, buffer);
         info.GetReturnValue().Set(result);
@@ -222,7 +222,7 @@ void Pointer::RegisterToDecimalStringMethod(Local<Context> context, Local<Object
         intptr_t ptr = static_cast<intptr_t>(reinterpret_cast<size_t>(value));
 
         char buffer[100];
-        sprintf(buffer, "%ld", ptr);
+        snprintf(buffer, 100, "%ld", ptr);
 
         Local<v8::String> result = tns::ToV8String(isolate, buffer);
         info.GetReturnValue().Set(result);

--- a/NativeScript/runtime/Reference.cpp
+++ b/NativeScript/runtime/Reference.cpp
@@ -295,9 +295,9 @@ void Reference::RegisterToStringMethod(Local<Context> context, Local<Object> pro
 
         char buffer[100];
         if (value == nullptr) {
-            sprintf(buffer, "<Reference: %p>", reinterpret_cast<void*>(0));
+            snprintf(buffer, 100, "<Reference: %p>", reinterpret_cast<void*>(0));
         } else {
-            sprintf(buffer, "<Reference: %p>", value);
+            snprintf(buffer, 100, "<Reference: %p>", value);
         }
 
         Local<v8::String> result = tns::ToV8String(isolate, buffer);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/ios",
   "description": "NativeScript Runtime for iOS",
-  "version": "8.3.2",
+  "version": "8.3.3-alpha.0",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
ios16 beta 5 crashes on boot with a trace somewhat similar to the one below. Adding a try/catch around `MethodMeta::isImplementedInClass` seems to catch the error, but ideally, we should figure out what caused the change in behavior.

The methods where it errors caught through the debugger (`po this->jsName()`):
```
attemptRecoveryFromErrorOptionIndex
attemptRecoveryFromErrorOptionIndexDelegateDidRecoverSelectorContextInfo
fileManagerShouldProceedAfterError
fileManagerWillProcessPath
provideImageDataBytesPerRowOriginSizeUserInfo
```


## Errors
```
+[__NSCFType allocWithZone:]: unrecognized selector sent to class 0x7ff863b44f30
```

```
0   CoreFoundation                	    0x7ff800427370 __exceptionPreprocess + 226
1   libobjc.A.dylib               	    0x7ff80004dbaf objc_exception_throw + 48
2   CoreFoundation                	    0x7ff8004364a1 __CFExceptionProem + 0
3   CoreFoundation                	    0x7ff800437173 +[__NSCFType allocWithZone:] + 20
4   NativeScript                  	       0x108874413 robin_hood::pair<objc_class*, objc_object*>::pair<objc_class*&, objc_object*>(objc_class*&, objc_object*&&) + 0 (robin_hood.h:603) [inlined]
5   NativeScript                  	       0x108874413 robin_hood::pair<objc_class*, objc_object*>::pair<objc_class*&, objc_object*>(objc_class*&, objc_object*&&) + 0 (robin_hood.h:604) [inlined]
6   NativeScript                  	       0x108874413 robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >::DataNode<robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >, true>::DataNode<objc_class*&, objc_object*>(robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >&, objc_class*&, objc_object*&&) + 0 (robin_hood.h:893) [inlined]
7   NativeScript                  	       0x108874413 robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >::DataNode<robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >, true>::DataNode<objc_class*&, objc_object*>(robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >&, objc_class*&, objc_object*&&) + 0 (robin_hood.h:893) [inlined]
8   NativeScript                  	       0x108874413 std::__1::pair<robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >::Iter<false>, bool> robin_hood::detail::Table<true, 80ul, objc_class*, objc_object*, robin_hood::hash<objc_class*>, std::__1::equal_to<objc_class*> >::emplace<objc_class*&, objc_object*>(objc_class*&, objc_object*&&) + 0 (robin_hood.h:1631) [inlined]
9   NativeScript                  	       0x108874413 tns::MethodMeta::isImplementedInClass(objc_class*, bool) const + 311 (Metadata.mm:79)
10  NativeScript                  	       0x108896fa9 tns::MetadataBuilder::RegisterInstanceMethods(v8::Local<v8::Context>, v8::Local<v8::FunctionTemplate>, tns::BaseClassMeta const*, tns::KnownUnknownClassPair, robin_hood::detail::Table<true, 80ul, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned char, robin_hood::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&) + 139 (MetadataBuilder.mm:428)
11  NativeScript                  	       0x108896161 tns::MetadataBuilder::GetOrCreateConstructorFunctionTemplateInternal(v8::Local<v8::Context>, tns::BaseClassMeta const*, tns::KnownUnknownClassPair, robin_hood::detail::Table<true, 80ul, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned char, robin_hood::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, robin_hood::detail::Table<true, 80ul, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, unsigned char, robin_hood::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > >&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 833 (MetadataBuilder.mm:332)
12  NativeScript                  	       0x108894862 tns::MetadataBuilder::GetOrCreateConstructorFunctionTemplate(v8::Local<v8::Context>, tns::BaseClassMeta const*, tns::KnownUnknownClassPair, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 90
13  NativeScript                  	       0x1088e410a std::__1::function<v8::Local<v8::FunctionTemplate> (v8::Local<v8::Context>, tns::BaseClassMeta const*, tns::KnownUnknownClassPair, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&)>::operator()(v8::Local<v8::Context>, tns::BaseClassMeta const*, tns::KnownUnknownClassPair, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) const + 54 (function.h:1182)
14  NativeScript                  	       0x108845609 tns::ArgConverter::CreateJsWrapper(v8::Local<v8::Context>, tns::BaseDataWrapper*, v8::Local<v8::Object>, bool, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) + 1621 (ArgConverter.mm:638)
15  NativeScript                  	       0x1088e3c61 tns::Interop::GetResult(v8::Local<v8::Context>, tns::TypeEncoding const*, tns::BaseCall*, bool, std::__1::shared_ptr<v8::Persistent<v8::Value, v8::NonCopyablePersistentTraits<v8::Value> > >, bool, bool, bool, bool) + 4523
16  NativeScript                  	       0x1088df123 tns::Interop::CallFunctionInternal(tns::MethodCall&) + 507
17  NativeScript                  	       0x108894a1b tns::MetadataBuilder::CFunctionCallback(v8::FunctionCallbackInfo<v8::Value> const&) + 237 (MetadataBuilder.mm:878)
18  NativeScript                  	       0x1089d698e v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo) + 606
19  NativeScript                  	       0x1089d5e17 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<false>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) + 727
20  NativeScript                  	       0x1089d536f v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) + 255
21  NativeScript                  	       0x109193a19 Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit + 57
```