### PR TITLE
fix: x86 simulators and add better failsafe around generated class names

### DIFF
--- a/NativeScript/runtime/ClassBuilder.cpp
+++ b/NativeScript/runtime/ClassBuilder.cpp
@@ -1,47 +1,18 @@
 #include "ClassBuilder.h"
-#if TARGET_CPU_X86_64 || TARGET_CPU_X86
-#include "SpinLock.h"
-#endif
 
 namespace tns {
 
 // Moved this method in a separate .cpp file because ARC destroys the class
 // created with objc_allocateClassPair when the control leaves this method scope
-// TODO: revist this as there are x86 simulator issues, so maybe a lock is
-// needed regardless
+// TODO: revist this. Maybe a lock is needed regardless
 Class ClassBuilder::GetExtendedClass(std::string baseClassName,
-                                     std::string staticClassName) {
-#if TARGET_CPU_X86_64 || TARGET_CPU_X86
-  // X86 simulators have this bugged, so we fallback to old behavior
-  static SpinMutex m;
-  SpinLock lock(m);
+                                     std::string staticClassName,
+                                     std::string suffix) {
   Class baseClass = objc_getClass(baseClassName.c_str());
   std::string name =
       !staticClassName.empty()
           ? staticClassName
-          : baseClassName + "_" +
-                std::to_string(++ClassBuilder::classNameCounter_);
-  Class clazz = objc_getClass(name.c_str());
-
-  if (clazz != nil) {
-    int i = 1;
-    std::string initialName = name;
-    while (clazz != nil) {
-      name = initialName + std::to_string(i++);
-      clazz = objc_getClass(name.c_str());
-    }
-  }
-
-  clazz = objc_allocateClassPair(baseClass, name.c_str(), 0);
-
-  objc_registerClassPair(clazz);
-  return clazz;
-#else
-  Class baseClass = objc_getClass(baseClassName.c_str());
-  std::string name =
-      !staticClassName.empty()
-          ? staticClassName
-          : baseClassName + "_" +
+          : baseClassName + suffix + "_" +
                 std::to_string(++ClassBuilder::classNameCounter_);
   // here we could either call objc_getClass with the name to see if the class
   // already exists or we can just try allocating it, which will return nil if
@@ -60,7 +31,6 @@ Class ClassBuilder::GetExtendedClass(std::string baseClassName,
 
   objc_registerClassPair(clazz);
   return clazz;
-#endif
 }
 
 }  // namespace tns

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -23,13 +23,13 @@ public:
 class ClassBuilder {
 public:
     static v8::Local<v8::FunctionTemplate> GetExtendFunction(v8::Isolate* isolate, const InterfaceMeta* interfaceMeta);
-    static Class GetExtendedClass(std::string baseClassName, std::string staticClassName);
+    static Class GetExtendedClass(std::string baseClassName, std::string staticClassName, std::string suffix);
 
     static void RegisterBaseTypeScriptExtendsFunction(v8::Local<v8::Context> context);
     static void RegisterNativeTypeScriptExtendsFunction(v8::Local<v8::Context> context);
     static std::string GetTypeEncoding(const TypeEncoding* typeEncoding, int argsCount);
 private:
-    static unsigned long long classNameCounter_;
+    static std::atomic<unsigned long long> classNameCounter_;
 
     static void ExtendCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void SuperAccessorGetterCallback(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value>& info);

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -219,8 +219,7 @@ bool IsArrayOrArrayLike(v8::Isolate* isolate,
 void* TryGetBufferFromArrayBuffer(const v8::Local<v8::Value>& value,
                                   bool& isArrayBuffer);
 
-void ExecuteOnRunLoop(CFRunLoopRef queue, std::function<void()> func,
-                      bool async = true);
+void ExecuteOnRunLoop(CFRunLoopRef queue, void (^func)(void), bool async = true);
 void ExecuteOnDispatchQueue(dispatch_queue_t queue, std::function<void()> func,
                             bool async = true);
 void ExecuteOnMainThread(std::function<void()> func, bool async = true);

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -331,7 +331,7 @@ struct LockAndCV {
     std::condition_variable cv;
 };
 
-void tns::ExecuteOnRunLoop(CFRunLoopRef queue, std::function<void ()> func, bool async) {
+void tns::ExecuteOnRunLoop(CFRunLoopRef queue, void (^func)(void), bool async) {
     if(!async) {
         bool __block finished = false;
         auto v = new LockAndCV;
@@ -350,12 +350,9 @@ void tns::ExecuteOnRunLoop(CFRunLoopRef queue, std::function<void ()> func, bool
         }
         delete v;
     } else {
-        CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, ^(void) {
-            func();
-        });
+        CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, func);
         CFRunLoopWakeUp(queue);
     }
-    
 }
 
 void tns::ExecuteOnDispatchQueue(dispatch_queue_t queue, std::function<void ()> func, bool async) {


### PR DESCRIPTION
fixes x86 sim issues that were caused by (compiler) conversions from objective-c blocks into std::function