### PR TITLE
feat: improve initialization with RAII patterns and runtime IDs

### DIFF
--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -1,6 +1,8 @@
 #ifndef Runtime_h
 #define Runtime_h
 
+#include <atomic>
+
 #include "Caches.h"
 #include "Common.h"
 #include "MetadataBuilder.h"
@@ -59,6 +61,7 @@ class Runtime {
   static thread_local Runtime* currentRuntime_;
   static std::shared_ptr<v8::Platform> platform_;
   static std::vector<v8::Isolate*> isolates_;
+  static std::atomic<int> nextRuntimeId_;
   static SpinMutex isolatesMutex_;
   static bool v8Initialized_;
   static std::atomic<int> nextIsolateId;

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -22,15 +22,15 @@
 #include "DisposerPHV.h"
 #include "IsolateWrapper.h"
 
+#include <mutex>
 #include <unordered_map>
+#include "DevFlags.h"
+#include "HMRSupport.h"
 #include "ModuleBinding.hpp"
 #include "ModuleInternalCallbacks.h"
 #include "URLImpl.h"
 #include "URLPatternImpl.h"
 #include "URLSearchParamsImpl.h"
-#include <mutex>
-#include "HMRSupport.h"
-#include "DevFlags.h"
 
 #define STRINGIZE(x) #x
 #define STRINGIZE_VALUE_OF(x) STRINGIZE(x)
@@ -128,7 +128,7 @@ namespace tns {
 std::atomic<int> Runtime::nextIsolateId{0};
 SimpleAllocator allocator_;
 NSDictionary* AppPackageJson = nil;
-static std::unordered_map<std::string, id> AppConfigCache; // generic cache for app config values
+static std::unordered_map<std::string, id> AppConfigCache;  // generic cache for app config values
 static std::mutex AppConfigCacheMutex;
 
 // Global flag to track when JavaScript errors occur during execution
@@ -261,6 +261,9 @@ Isolate* Runtime::CreateIsolate() {
     v8Initialized_ = true;
   }
 
+  int runtimeId = Runtime::nextRuntimeId_.fetch_add(1, std::memory_order_relaxed);
+  this->SetWorkerId(runtimeId);
+
   startTime = platform_->MonotonicallyIncreasingTime();
   realtimeOrigin = platform_->CurrentClockTimeMillis();
 
@@ -301,8 +304,8 @@ void Runtime::Init(Isolate* isolate, bool isWorker) {
   DefineDrainMicrotaskMethod(isolate, globalTemplate);
   // queueMicrotask(callback) per spec
   {
-    Local<FunctionTemplate> qmtTemplate = FunctionTemplate::New(
-        isolate, [](const FunctionCallbackInfo<Value>& info) {
+    Local<FunctionTemplate> qmtTemplate =
+        FunctionTemplate::New(isolate, [](const FunctionCallbackInfo<Value>& info) {
           auto* isolate = info.GetIsolate();
           if (info.Length() < 1 || !info[0]->IsFunction()) {
             isolate->ThrowException(Exception::TypeError(
@@ -434,6 +437,11 @@ void Runtime::RunMainScript() {
   v8::Locker locker(isolate);
   Isolate::Scope isolate_scope(isolate);
   HandleScope handle_scope(isolate);
+
+  auto cache = Caches::Get(isolate);
+  auto context = cache->GetContext();
+  Context::Scope context_scope(context);
+
   this->moduleInternal_->RunModule(isolate, "./");
 }
 
@@ -488,7 +496,8 @@ id Runtime::GetAppConfigValue(std::string key) {
     result = AppPackageJson[nsKey];
   }
 
-  // Store in cache (can cache nil as NSNull to differentiate presence if desired; for now, cache as-is)
+  // Store in cache (can cache nil as NSNull to differentiate presence if desired; for now, cache
+  // as-is)
   {
     std::lock_guard<std::mutex> lock(AppConfigCacheMutex);
     AppConfigCache[key] = result;
@@ -624,6 +633,7 @@ std::shared_ptr<Platform> Runtime::platform_;
 std::vector<Isolate*> Runtime::isolates_;
 bool Runtime::v8Initialized_ = false;
 thread_local Runtime* Runtime::currentRuntime_ = nullptr;
+std::atomic<int> Runtime::nextRuntimeId_ = {0};
 SpinMutex Runtime::isolatesMutex_;
 
 }  // namespace tns


### PR DESCRIPTION
This PR improves runtime initialization correctness and modernizes V8 API usage:

**Context Management (RAII):**
Adds `Context::Scope` RAII pattern to `RunMainScript` for proper context handling. The `Context::Scope` ensures the context is correctly exited when the scope ends, even if exceptions occur. This is the recommended V8 C++ API pattern per `v8-locker.h` documentation.

Note: `Runtime::Init` continues to use manual `context->Enter()` because the context must remain entered for the runtime's entire lifetime, not just during initialization.

**Runtime ID Generation:**
Introduces a static atomic counter (`nextRuntimeId_`) that generates unique IDs for each `Runtime` instance during initialization. This provides reliable runtime identification for both main and worker threads using thread-safe atomic operations with `memory_order_relaxed` (appropriate for ID generation).

The patterns align with modern C++ best practices and V8 API recommendations.