### PR TITLE
fix: prevent global Promise overwrite for thread safety.

### DIFF
--- a/NativeScript/runtime/PromiseProxy.cpp
+++ b/NativeScript/runtime/PromiseProxy.cpp
@@ -72,6 +72,27 @@ void PromiseProxy::Init(v8::Local<v8::Context> context) {
                     });
                 }
             });
+            globalThis = new Proxy(globalThis, {
+                defineProperty: (target, prop, descriptor) => {
+                    if (prop === 'Promise') {
+                        return true;
+                    }
+                    return Object.defineProperty(target, prop, descriptor);
+                },
+                set: (target, prop, value, receiver) => {
+                    if (prop === 'Promise') {
+                        return true;
+                    }
+
+                    const descriptor = Object.getOwnPropertyDescriptor(target, prop);
+                    if (descriptor && !descriptor.writable) {
+                        return false;
+                    }
+
+                    target[prop] = value;
+                    return true;
+                }
+            });
         })();
     )";
 


### PR DESCRIPTION
This PR ensures thread safety for Promises by preventing the global `Promise` object from being overwritten by user-space code or 3rd party libraries.

NativeScript relies on a custom Promise proxy implementation to ensure that callbacks are executed on the same thread where they were created. This is critical for iOS, where UI updates must happen on the main thread.

Some JavaScript libraries (e.g., Mocha) attempt to replace the global `Promise` with their own implementation or polyfill. If this happens, the runtime's thread marshalling logic is lost, leading to deadlocks, race conditions, or crashes when callbacks run on the wrong thread.

This change wraps `globalThis` in a Proxy during initialization to intercept and silently block any attempts to redefine or assign to the `Promise` property, strictly preserving the runtime's thread-safe implementation.

Note: This has been battle-tested since Nov 2020 in a project I work on.