### PR TITLE
fix: node built-in modules handling

### DIFF
--- a/TestRunner/app/tests/NodeBuiltinsAndOptionalModulesTests.mjs
+++ b/TestRunner/app/tests/NodeBuiltinsAndOptionalModulesTests.mjs
@@ -1,0 +1,35 @@
+describe("Node built-in and optional module resolution", function () {
+  it("provides an in-memory polyfill for node:url", async function () {
+    // Dynamic import to exercise ResolveModuleCallback ESM path.
+    const mod = await import("node:url");
+
+    expect(mod).toBeDefined();
+    expect(typeof mod.fileURLToPath).toBe("function");
+    expect(typeof mod.pathToFileURL).toBe("function");
+
+    const p = mod.fileURLToPath("file:///foo/bar.txt");
+    expect(p === "/foo/bar.txt" || p === "foo/bar.txt").toBe(true);
+
+    const u = mod.pathToFileURL("/foo/bar.txt");
+    expect(u instanceof URL).toBe(true);
+    expect(u.protocol).toBe("file:");
+  });
+
+  it("creates an in-memory placeholder for likely-optional modules", async function () {
+    // Use a name that IsLikelyOptionalModule will treat as optional (no slashes, no extension).
+    const mod = await import("__ns_optional_test_module__");
+
+    expect(mod).toBeDefined();
+    expect(typeof mod.default).toBe("object");
+
+    let threw = false;
+    try {
+      // Any property access should throw according to the placeholder implementation.
+      // eslint-disable-next-line no-unused-expressions
+      mod.default.someProperty;
+    } catch (e) {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+});

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -87,6 +87,9 @@ require("./URLPattern");
 // HTTP ESM Loader tests
 require("./HttpEsmLoaderTests");
 
+// Node built-in and optional module resolution tests (ESM)
+require("./NodeBuiltinsAndOptionalModulesTests.mjs");
+
 // Exception handling tests
 require("./ExceptionHandlingTests");
 


### PR DESCRIPTION
- Node.js built-in modules (e.g., `node:url`) are now resolved by creating in-memory polyfill modules, registered and reused in a virtual registry, instead of writing polyfill files to disk. 
- Added new tests to verify that built-in modules like `node:url` and optional modules are resolved correctly using the new in-memory approach. 
- The `pathToFileURL` polyfill now encodes paths more accurately by replacing `%2F` with `/`, ensuring correct URL formatting. 