### PR TITLE
docs: Clarify timer cleanup comment in removeTask

### DIFF
--- a/NativeScript/runtime/Timers.cpp
+++ b/NativeScript/runtime/Timers.cpp
@@ -65,11 +65,8 @@ class TimerState {
       it->second->Unschedule();
       timerMap_.erase(it);
       CFRunLoopTimerInvalidate(timer);
-      // timer and context will be released by the retain function
-      // CFRunLoopTimerContext context;
-      // CFRunLoopTimerGetContext(timer, &context);
-      // delete static_cast<std::shared_ptr<TimerTask>*>(context.info);
-      // CFRelease(timer);
+      // CFRunLoopTimerInvalidate triggers our TimerRelease callback, which
+      // deletes TimerContext, whose destructor calls CFRelease(task->timer)
     }
   }
 


### PR DESCRIPTION
## Summary

- Clarified the comment in `removeTask` to better explain the timer cleanup flow
- Removed stale commented-out code

## Context

While investigating timer memory management, I tested uncommenting the `CFRelease(timer)` call and confirmed it causes a double-free crash. This validates that the current implementation is correct.

The new comment clearly explains the cleanup flow:
- `CFRunLoopTimerInvalidate` triggers our `TimerRelease` callback
- This deletes `TimerContext`, whose destructor calls `CFRelease(task->timer)`

## Why this clarification helps

Apple's [CFRunLoopTimerInvalidate](https://developer.apple.com/documentation/corefoundation/cfrunlooptimerinvalidate(_:)) documentation states:

> "The memory is not deallocated unless the run loop held the only reference to timer."

This does not make it obvious that invalidation also triggers the context's release callback, which is what actually handles the cleanup in this implementation.

## Test plan

- [x] Verified that uncommenting `CFRelease(timer)` crashes (double-free)
- [x] Confirmed the existing code correctly cleans up timers via the destructor chain