### PR TITLE
fix: Xcode 26.4 build

### DIFF
--- a/NativeScript/inspector/JsV8InspectorClient.mm
+++ b/NativeScript/inspector/JsV8InspectorClient.mm
@@ -22,6 +22,13 @@ using json = nlohmann::json;
 
 namespace v8_inspector {
 
+namespace {
+StringView Make8BitStringView(const std::string& value) {
+  return StringView(reinterpret_cast<const uint8_t*>(value.data()),
+                    value.size());
+}
+}  // namespace
+
 #define NOTIFICATION(name)                                 \
   [[NSString stringWithFormat:@"%@:NativeScript.Debug.%s", \
                               [[NSBundle mainBundle] bundleIdentifier], name] UTF8String]
@@ -257,8 +264,7 @@ void JsV8InspectorClient::notify(const std::string& message) {
 }
 
 void JsV8InspectorClient::dispatchMessage(const std::string& message) {
-  std::vector<uint16_t> vector = tns::ToVector(message);
-  StringView messageView(vector.data(), vector.size());
+  StringView messageView = Make8BitStringView(message);
   Isolate* isolate = isolate_;
   v8::Locker locker(isolate);
   Isolate::Scope isolate_scope(isolate);
@@ -343,8 +349,7 @@ void JsV8InspectorClient::dispatchMessage(const std::string& message) {
       auto returnString = GetReturnMessageFromDomainHandlerResult(result, requestId);
 
       if (returnString.size() > 0) {
-        std::vector<uint16_t> vector = tns::ToVector(returnString);
-        StringView messageView(vector.data(), vector.size());
+        StringView messageView = Make8BitStringView(returnString);
         auto msg = StringBuffer::create(messageView);
         this->sendNotification(std::move(msg));
       }
@@ -486,8 +491,7 @@ void JsV8InspectorClient::inspectorSendEventCallback(const FunctionCallbackInfo<
   Local<v8::String> arg = args[0].As<v8::String>();
   std::string message = tns::ToString(isolate, arg);
 
-  std::vector<uint16_t> vector = tns::ToVector(message);
-  StringView messageView(vector.data(), vector.size());
+  StringView messageView = Make8BitStringView(message);
   auto msg = StringBuffer::create(messageView);
   client->sendNotification(std::move(msg));
 }

--- a/NativeScript/inspector/src/inspector/string-16.h
+++ b/NativeScript/inspector/src/inspector/string-16.h
@@ -17,7 +17,7 @@
 
 namespace v8_inspector {
 
-using UChar = uint16_t;
+using UChar = char16_t;
 
 class String16 {
  public:

--- a/NativeScript/inspector/src/inspector/string-util.h
+++ b/NativeScript/inspector/src/inspector/string-util.h
@@ -30,13 +30,13 @@ class StringUtil {
   }
 
   static String fromUTF16LE(const uint16_t* data, size_t length) {
-    return String16::fromUTF16LE(data, length);
+    return String16::fromUTF16LE(reinterpret_cast<const UChar*>(data), length);
   }
 
   static const uint8_t* CharactersLatin1(const String& s) { return nullptr; }
   static const uint8_t* CharactersUTF8(const String& s) { return nullptr; }
   static const uint16_t* CharactersUTF16(const String& s) {
-    return s.characters16();
+    return reinterpret_cast<const uint16_t*>(s.characters16());
   }
   static size_t CharacterCount(const String& s) { return s.length(); }
 };

--- a/NativeScript/inspector/utils.mm
+++ b/NativeScript/inspector/utils.mm
@@ -35,16 +35,15 @@ std::string v8_inspector::GetMIMEType(std::string filePath) {
 }
 
 std::string v8_inspector::ToStdString(const StringView& value) {
-    std::vector<uint16_t> buffer(value.length());
+    std::u16string value16;
+    value16.resize(value.length());
     for (size_t i = 0; i < value.length(); i++) {
         if (value.is8Bit()) {
-            buffer[i] = value.characters8()[i];
+            value16[i] = static_cast<char16_t>(value.characters8()[i]);
         } else {
-            buffer[i] = value.characters16()[i];
+            value16[i] = static_cast<char16_t>(value.characters16()[i]);
         }
     }
-
-    std::u16string value16(buffer.begin(), buffer.end());
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // FIXME: std::codecvt_utf8_utf16 is deprecated

--- a/NativeScript/v8runtime/V8Runtime.cpp
+++ b/NativeScript/v8runtime/V8Runtime.cpp
@@ -431,7 +431,7 @@ std::shared_ptr<const jsi::PreparedJavaScript> V8Runtime::prepareJavaScript(
 
 jsi::Value V8Runtime::evaluatePreparedJavaScript(
     const std::shared_ptr<const jsi::PreparedJavaScript>& js) {
-  return evaluateJavaScript(nullptr, nullptr);
+  return evaluateJavaScript(nullptr, "");
 }
 
 void V8Runtime::queueMicrotask(const jsi::Function& callback) {

--- a/download_llvm.sh
+++ b/download_llvm.sh
@@ -2,7 +2,7 @@
 set -e
 source "$(dirname "$0")/build_utils.sh"
 
-LLVM_VERSION="17.0.6"
+LLVM_VERSION="17.0.7"
 
 function download_llvm() {
     checkpoint "Downloading llvm (version $LLVM_VERSION)..."

--- a/metadata-generator/CMakeLists.txt
+++ b/metadata-generator/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(MetadataGenerator)
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -13,7 +14,7 @@ if (NOT LIBXML2_FOUND)
     message(FATAL_ERROR "libXML2 not found")
 endif ()
 
-get_filename_component(LLVM_ROOT "../../llvm/17.0.6" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+get_filename_component(LLVM_ROOT "../../llvm/17.0.7" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
 
 set(LLVM_SYSTEM_LIBS "-lz -lcurses -lm -lxml2")
@@ -34,6 +35,18 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target ${METADATA_BINARY_ARCH}-apple-da
 check_c_compiler_flag(-Wno-unused-but-set-variable HAS_UNUSED_BUT_SET_VARIABLE)
 if (HAS_UNUSED_BUT_SET_VARIABLE)
     add_compile_options(-Wno-unused-but-set-variable)
+endif()
+
+# LLVM 17.0.7 triggers this diagnostic in Clang's own headers on newer Apple toolchains.
+# Keep warnings-as-errors for project code, but don't fail the build on this upstream warning.
+check_cxx_compiler_flag(-Wno-error=preferred-type-bitfield-enum-conversion HAS_NO_ERROR_PREFERRED_TYPE_BITFIELD_ENUM_CONVERSION)
+if (HAS_NO_ERROR_PREFERRED_TYPE_BITFIELD_ENUM_CONVERSION)
+    add_compile_options(-Wno-error=preferred-type-bitfield-enum-conversion)
+endif()
+
+check_cxx_compiler_flag(-Wno-error=unnecessary-virtual-specifier HAS_NO_ERROR_UNNECESSARY_VIRTUAL_SPECIFIER)
+if (HAS_NO_ERROR_UNNECESSARY_VIRTUAL_SPECIFIER)
+    add_compile_options(-Wno-error=unnecessary-virtual-specifier)
 endif()
 
 set(LLVM_LINKER_FLAGS "${LLVM_LINKER_FLAGS} ${LLVM_SYSTEM_LIBS} ${LLVM_LIBS}")

--- a/metadata-generator/src/Binary/binarySerializer.cpp
+++ b/metadata-generator/src/Binary/binarySerializer.cpp
@@ -254,7 +254,7 @@ static llvm::ErrorOr<bool> isStaticFramework(clang::Module* framework)
 
     if (path.getError()) {
         return path.getError();
-    } else if (path.get().endswith(".tbd")) {
+    } else if (path.get().ends_with(".tbd")) {
         return true;
     }
 

--- a/metadata-generator/src/HeadersParser/Parser.cpp
+++ b/metadata-generator/src/HeadersParser/Parser.cpp
@@ -6,6 +6,7 @@
 #include <clang/Tooling/Tooling.h>
 #include <iostream>
 #include <sstream>
+#include <variant>
 #include <llvm/ADT/StringSwitch.h>
 #include <llvm/Support/Path.h>
 
@@ -31,9 +32,9 @@ static std::error_code addHeaderInclude(StringRef headerName, std::vector<SmallS
     return std::error_code();
 }
 
-static std::error_code addHeaderInclude(const FileEntry* header, std::vector<SmallString<256>>& includes)
+static std::error_code addHeaderInclude(FileEntryRef header, std::vector<SmallString<256>>& includes)
 {
-    return addHeaderInclude(header->getName(), includes);
+    return addHeaderInclude(header.getName(), includes);
 }
 
 static std::error_code collectModuleHeaderIncludes(FileManager& fileMgr, ModuleMap& modMap, const Module* module, std::vector<SmallString<256>>& includes)
@@ -42,17 +43,15 @@ static std::error_code collectModuleHeaderIncludes(FileManager& fileMgr, ModuleM
     if (!module->isAvailable())
         return std::error_code();
 
-    if (module->Umbrella && module->Umbrella.is<FileEntryRef>()) {
-        const FileEntry* umbrellaHeader = module->Umbrella.get<FileEntryRef>();
-        if (std::error_code err = addHeaderInclude(umbrellaHeader, includes))
+    if (const auto* umbrellaHeader = std::get_if<FileEntryRef>(&module->Umbrella)) {
+        if (std::error_code err = addHeaderInclude(*umbrellaHeader, includes))
             return err;
     }
-    else if (module->Umbrella && module->Umbrella.is<DirectoryEntryRef>()) {
-        const DirectoryEntryRef umbrellaDir = module->Umbrella.get<DirectoryEntryRef>();
+    else if (const auto* umbrellaDir = std::get_if<DirectoryEntryRef>(&module->Umbrella)) {
         // Add all of the headers we find in this subdirectory.
         std::error_code ec;
         SmallString<128> dirNative;
-        path::native(umbrellaDir.getName(), dirNative);
+        path::native(umbrellaDir->getName(), dirNative);
         for (fs::recursive_directory_iterator dir(dirNative.str(), ec), dirEnd; dir != dirEnd && !ec; dir.increment(ec)) {
             // Check whether this entry has an extension typically associated with headers.
             if (!llvm::StringSwitch<bool>(path::extension(dir->path()))
@@ -77,8 +76,8 @@ static std::error_code collectModuleHeaderIncludes(FileManager& fileMgr, ModuleM
         if (ec)
             return ec;
     } else {
-        for (auto header : module->Headers[Module::HK_Normal]) {
-            if (auto err = addHeaderInclude(header.Entry, includes))
+        for (FileEntryRef header : const_cast<Module*>(module)->getTopHeaders(fileMgr)) {
+            if (auto err = addHeaderInclude(header, includes))
                 return err;
         }
     }

--- a/metadata-generator/src/HeadersParser/Parser.cpp
+++ b/metadata-generator/src/HeadersParser/Parser.cpp
@@ -76,8 +76,8 @@ static std::error_code collectModuleHeaderIncludes(FileManager& fileMgr, ModuleM
         if (ec)
             return ec;
     } else {
-        for (FileEntryRef header : const_cast<Module*>(module)->getTopHeaders(fileMgr)) {
-            if (auto err = addHeaderInclude(header, includes))
+        for (auto header : module->getHeaders(Module::HK_Normal)) {
+            if (auto err = addHeaderInclude(header.Entry, includes))
                 return err;
         }
     }

--- a/metadata-generator/src/TypeScript/DefinitionWriter.cpp
+++ b/metadata-generator/src/TypeScript/DefinitionWriter.cpp
@@ -583,7 +583,7 @@ std::string DefinitionWriter::writeMethod(MethodMeta* meta, BaseClassMeta* owner
         }
     }
 
-    if ((owner->type == MetaType::Protocol && methodDecl.getImplementationControl() == clang::ObjCMethodDecl::ImplementationControl::Optional) || (owner->is(MetaType::Protocol) && meta->getFlags(MethodIsInitializer))) {
+    if ((owner->type == MetaType::Protocol && methodDecl.getImplementationControl() == clang::ObjCImplementationControl::Optional) || (owner->is(MetaType::Protocol) && meta->getFlags(MethodIsInitializer))) {
         output << "?";
     }
 


### PR DESCRIPTION
- llvm 17.0.7
- updated signatures

Projects build/run fine already with latest 9.0.3 release with Xcode 26.4, this just addresses building the runtime and metadata-generator (as well as running the TestRunner) with 26.4.