### PR TITLE
revert: "fix: prevent crash during debug on fast view churn (like with HMR)"

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -7,7 +7,6 @@
 #include "Interop.h"
 #include "Helpers.h"
 #include "Runtime.h"
-#include "RuntimeConfig.h"
 
 using namespace v8;
 using namespace std;
@@ -28,24 +27,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
     bool callSuper = false;
     if (instanceMethod) {
         BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
-        
-        if (wrapper == nullptr) {
-            // During fast view churn like HMR in development, JS objects can outlive their
-            // native wrappers briefly. In Debug, throw a catchable JS error instead of crashing.
-            // In Release, assert so crash reporting can capture unexpected cases.
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                std::string errMsg = std::string("Cannot call method '") + jsNameStr +
-                    "' on a disposed native object (class: " + classNameStr +
-                    ", selector: " + selectorStr + "). This can happen during HMR or fast view churn.";
-                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
-                return v8::Undefined(isolate);
-            } else {
-                tns::Assert(false, isolate);
-            }
-        }
+        tns::Assert(wrapper != nullptr, isolate);
 
         if (wrapper->Type() == WrapperType::ObjCAllocObject) {
             ObjCAllocDataWrapper* allocWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
@@ -61,19 +43,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
             // For extended classes we will call the base method
             callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
         } else {
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                std::string errMsg = std::string("Unexpected receiver wrapper type ") +
-                    std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
-                    "' (class: " + classNameStr + ", selector: " + selectorStr +
-                    "). This can happen during HMR or fast view churn.";
-                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
-                return v8::Undefined(isolate);
-            } else {
-                tns::Assert(false, isolate);
-            }
+            tns::Assert(false, isolate);
         }
     }
 
@@ -908,7 +878,7 @@ void ArgConverter::IndexedPropertySetterCallback(uint32_t index, Local<Value> va
     Local<Object> thiz = args.This();
     Isolate* isolate = args.GetIsolate();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
-    if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
+    if (wrapper == nullptr && wrapper->Type() != WrapperType::ObjCObject) {
         return;
     }
 

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -1,6 +1,5 @@
 #include <Foundation/Foundation.h>
 #include <sstream>
-#include <unordered_set>
 #include "ArgConverter.h"
 #include "NativeScriptException.h"
 #include "DictionaryAdapter.h"
@@ -8,7 +7,6 @@
 #include "Interop.h"
 #include "Helpers.h"
 #include "Runtime.h"
-#include "RuntimeConfig.h"
 
 using namespace v8;
 using namespace std;
@@ -29,27 +27,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
     bool callSuper = false;
     if (instanceMethod) {
         BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
-        
-        if (wrapper == nullptr) {
-            // During fast view churn like HMR in development, JS objects can outlive their
-            // native wrappers briefly. In Debug, avoid a crash and just skip the native call.
-            // In Release, assert so crash reporting can capture unexpected cases.
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                // Suppress duplicate logs: only log once per class+selector for this process.
-                static std::unordered_set<std::string> s_logged;
-                std::string key = std::string(classNameStr) + ":" + selectorStr;
-                if (s_logged.insert(key).second) {
-                    Log(@"Note: ignore method on non-native receiver (class: %s, selector: %s, jsName: %s, args: %d). Common during HMR.",
-                        classNameStr, selectorStr, jsNameStr, (int)args.Length());
-                }
-                return v8::Undefined(isolate);
-            } else {
-                tns::Assert(false, isolate);
-            }
-        }
+        tns::Assert(wrapper != nullptr, isolate);
 
         if (wrapper->Type() == WrapperType::ObjCAllocObject) {
             ObjCAllocDataWrapper* allocWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
@@ -65,21 +43,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
             // For extended classes we will call the base method
             callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
         } else {
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                // Suppress duplicate logs: only log once per class+selector for this process.
-                static std::unordered_set<std::string> s_logged;
-                std::string key = std::string(classNameStr) + ":" + selectorStr;
-                if (s_logged.insert(key).second) {
-                    Log(@"Note: ignore receiver wrapper type %d (class: %s, selector: %s, jsName: %s). Common during HMR.",
-                        (int)wrapper->Type(), classNameStr, selectorStr, jsNameStr);
-                }
-                return v8::Undefined(isolate);
-            } else {
-                tns::Assert(false, isolate);
-            }
+            tns::Assert(false, isolate);
         }
     }
 
@@ -914,7 +878,7 @@ void ArgConverter::IndexedPropertySetterCallback(uint32_t index, Local<Value> va
     Local<Object> thiz = args.This();
     Isolate* isolate = args.GetIsolate();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
-    if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
+    if (wrapper == nullptr && wrapper->Type() != WrapperType::ObjCObject) {
         return;
     }
 

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -7,6 +7,7 @@
 #include "Interop.h"
 #include "Helpers.h"
 #include "Runtime.h"
+#include "RuntimeConfig.h"
 
 using namespace v8;
 using namespace std;
@@ -27,7 +28,24 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
     bool callSuper = false;
     if (instanceMethod) {
         BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
-        tns::Assert(wrapper != nullptr, isolate);
+        
+        if (wrapper == nullptr) {
+            // During fast view churn like HMR in development, JS objects can outlive their
+            // native wrappers briefly. In Debug, throw a catchable JS error instead of crashing.
+            // In Release, assert so crash reporting can capture unexpected cases.
+            if (RuntimeConfig.IsDebug) {
+                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
+                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
+                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
+                std::string errMsg = std::string("Cannot call method '") + jsNameStr +
+                    "' on a disposed native object (class: " + classNameStr +
+                    ", selector: " + selectorStr + "). This can happen during HMR or fast view churn.";
+                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
+                return v8::Undefined(isolate);
+            } else {
+                tns::Assert(false, isolate);
+            }
+        }
 
         if (wrapper->Type() == WrapperType::ObjCAllocObject) {
             ObjCAllocDataWrapper* allocWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
@@ -43,7 +61,19 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
             // For extended classes we will call the base method
             callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
         } else {
-            tns::Assert(false, isolate);
+            if (RuntimeConfig.IsDebug) {
+                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
+                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
+                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
+                std::string errMsg = std::string("Unexpected receiver wrapper type ") +
+                    std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
+                    "' (class: " + classNameStr + ", selector: " + selectorStr +
+                    "). This can happen during HMR or fast view churn.";
+                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
+                return v8::Undefined(isolate);
+            } else {
+                tns::Assert(false, isolate);
+            }
         }
     }
 
@@ -878,7 +908,7 @@ void ArgConverter::IndexedPropertySetterCallback(uint32_t index, Local<Value> va
     Local<Object> thiz = args.This();
     Isolate* isolate = args.GetIsolate();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
-    if (wrapper == nullptr && wrapper->Type() != WrapperType::ObjCObject) {
+    if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
         return;
     }
 


### PR DESCRIPTION
Reverts NativeScript/ios#294

This "fix" gets rid of an important part of the runtime stability where you can do something like:

```
const myNativeClass = SomeNSClass.new();
// myNativeClass is weakly held and we make SomeNSClass weak and it gets released
const value = myNativeClass.someNativeMethodThatAlwaysReturns(); // no error, just returns undefined
```

when this happens the error will not be thrown and cannot be caught, so if it happens you NEED to be looking at the console because it won't be caught by sentry/crashlytics/etc in production.