### PR TITLE
fix: throw JS exception instead of silent warning for disposed native object calls in debug mode

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -40,8 +40,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
                 std::string errMsg = std::string("Cannot call method '") + jsNameStr +
                     "' on a disposed native object (class: " + classNameStr +
                     ", selector: " + selectorStr + "). This can happen during HMR or fast view churn.";
-                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
-                return v8::Undefined(isolate);
+                throw NativeScriptException(isolate, errMsg);
             } else {
                 tns::Assert(false, isolate);
             }
@@ -69,8 +68,7 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
                     std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
                     "' (class: " + classNameStr + ", selector: " + selectorStr +
                     "). This can happen during HMR or fast view churn.";
-                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
-                return v8::Undefined(isolate);
+                throw NativeScriptException(isolate, errMsg);
             } else {
                 tns::Assert(false, isolate);
             }

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -1,6 +1,5 @@
 #include <Foundation/Foundation.h>
 #include <sstream>
-#include <unordered_set>
 #include "ArgConverter.h"
 #include "NativeScriptException.h"
 #include "DictionaryAdapter.h"
@@ -32,19 +31,16 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
         
         if (wrapper == nullptr) {
             // During fast view churn like HMR in development, JS objects can outlive their
-            // native wrappers briefly. In Debug, avoid a crash and just skip the native call.
+            // native wrappers briefly. In Debug, throw a catchable JS error instead of crashing.
             // In Release, assert so crash reporting can capture unexpected cases.
             if (RuntimeConfig.IsDebug) {
                 const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
                 const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
                 const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                // Suppress duplicate logs: only log once per class+selector for this process.
-                static std::unordered_set<std::string> s_logged;
-                std::string key = std::string(classNameStr) + ":" + selectorStr;
-                if (s_logged.insert(key).second) {
-                    Log(@"Note: ignore method on non-native receiver (class: %s, selector: %s, jsName: %s, args: %d). Common during HMR.",
-                        classNameStr, selectorStr, jsNameStr, (int)args.Length());
-                }
+                std::string errMsg = std::string("Cannot call method '") + jsNameStr +
+                    "' on a disposed native object (class: " + classNameStr +
+                    ", selector: " + selectorStr + "). This can happen during HMR or fast view churn.";
+                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
                 return v8::Undefined(isolate);
             } else {
                 tns::Assert(false, isolate);
@@ -69,13 +65,11 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
                 const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
                 const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
                 const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                // Suppress duplicate logs: only log once per class+selector for this process.
-                static std::unordered_set<std::string> s_logged;
-                std::string key = std::string(classNameStr) + ":" + selectorStr;
-                if (s_logged.insert(key).second) {
-                    Log(@"Note: ignore receiver wrapper type %d (class: %s, selector: %s, jsName: %s). Common during HMR.",
-                        (int)wrapper->Type(), classNameStr, selectorStr, jsNameStr);
-                }
+                std::string errMsg = std::string("Unexpected receiver wrapper type ") +
+                    std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
+                    "' (class: " + classNameStr + ", selector: " + selectorStr +
+                    "). This can happen during HMR or fast view churn.";
+                isolate->ThrowException(Exception::Error(tns::ToV8String(isolate, errMsg)));
                 return v8::Undefined(isolate);
             } else {
                 tns::Assert(false, isolate);


### PR DESCRIPTION
- Replaces silent `Log()` warnings with proper `isolate->ThrowException()` calls when
  invoking methods on disposed native objects in debug mode
- Provides specific, actionable error messages that name the method, class, and selector
- Still avoids crashing the app in debug mode

## Context

The change in #294 (42a5328) prevented crashes during HMR (debug mode only) by replacing `tns::Assert` with
a `Log()` warning that silently returned `v8::Undefined`. While this fixed the crash, it
introduced a regression: errors became undetectable from JS, and `undefined` values could
silently leak into arrays and other data structures.

This fix takes the middle path — a catchable JS exception that:
1. Doesn't crash the app (HMR-safe)
2. Is detectable via `try/catch`
3. Prevents silent `undefined` propagation
4. Gives developers a clear message about what went wrong