### PR TITLE
feat: add more null types for types the runtime accept or returns as null

### DIFF
--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
@@ -293,6 +293,12 @@ binary::BinaryTypeEncodingSerializer::visitNullable(
 }
 
 unique_ptr<binary::TypeEncoding>
+binary::BinaryTypeEncodingSerializer::visitNonNullable(
+    const ::Meta::NonNullableType& type) {
+  return type.innerType->visit(*this);
+}
+
+unique_ptr<binary::TypeEncoding>
 binary::BinaryTypeEncodingSerializer::serializeRecordEncoding(
     const binary::BinaryTypeEncodingType encodingType,
     const std::vector< ::Meta::RecordField>& fields) {

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
@@ -118,5 +118,8 @@ class BinaryTypeEncodingSerializer
 
   virtual unique_ptr<TypeEncoding> visitNullable(
       const ::Meta::NullableType& type) override;
+
+  virtual unique_ptr<TypeEncoding> visitNonNullable(
+      const ::Meta::NonNullableType& type) override;
 };
 }  // namespace binary

--- a/metadata-generator/src/Meta/NameRetrieverVisitor.cpp
+++ b/metadata-generator/src/Meta/NameRetrieverVisitor.cpp
@@ -178,6 +178,11 @@ std::string NameRetrieverVisitor::visitNullable(
   return type.innerType->visit(*this);
 }
 
+std::string NameRetrieverVisitor::visitNonNullable(
+    const ::Meta::NonNullableType& type) {
+  return type.innerType->visit(*this);
+}
+
 std::string NameRetrieverVisitor::generateFixedArray(const Type* el_type,
                                                      size_t size) {
   std::stringstream ss(el_type->visit(*this));

--- a/metadata-generator/src/Meta/NameRetrieverVisitor.h
+++ b/metadata-generator/src/Meta/NameRetrieverVisitor.h
@@ -99,6 +99,8 @@ class NameRetrieverVisitor : public ::Meta::TypeVisitor<std::string> {
 
   virtual std::string visitNullable(const ::Meta::NullableType& type);
 
+  virtual std::string visitNonNullable(const ::Meta::NonNullableType& type);
+
  private:
   NameRetrieverVisitor(bool tsNames) : tsNames(tsNames) {}
 

--- a/metadata-generator/src/Meta/TypeEntities.h
+++ b/metadata-generator/src/Meta/TypeEntities.h
@@ -50,7 +50,8 @@ enum TypeType {
   TypeEnum,
   TypeTypeArgument,
   TypeExtVector,
-  TypeNullable
+  TypeNullable,
+  TypeNonNullable
 };
 
 class Type {
@@ -150,6 +151,8 @@ class Type {
         return visitor.visitExtVector(as<ExtVectorType>());
       case TypeNullable:
         return visitor.visitNullable(as<NullableType>());
+      case TypeNonNullable:
+        return visitor.visitNonNullable(as<NonNullableType>());
     }
   }
 
@@ -321,6 +324,14 @@ class NullableType : public Type {
  public:
   NullableType(Type* innerType)
       : Type(TypeType::TypeNullable), innerType(innerType) {}
+
+  Type* innerType;
+};
+
+class NonNullableType : public Type {
+ public:
+  NonNullableType(Type* innerType)
+      : Type(TypeType::TypeNonNullable), innerType(innerType) {}
 
   Type* innerType;
 };

--- a/metadata-generator/src/Meta/TypeFactory.cpp
+++ b/metadata-generator/src/Meta/TypeFactory.cpp
@@ -508,6 +508,8 @@ shared_ptr<Type> TypeFactory::createFromAttributedType(
   if (auto nullability = type->getImmediateNullability()) {
     if (*nullability == clang::NullabilityKind::Nullable) {
       return make_shared<NullableType>(innerType.get());
+    } else if (*nullability == clang::NullabilityKind::NonNull) {
+      return make_shared<NonNullableType>(innerType.get());
     }
   }
   return innerType;

--- a/metadata-generator/src/Meta/TypeVisitor.h
+++ b/metadata-generator/src/Meta/TypeVisitor.h
@@ -19,6 +19,7 @@ class EnumType;
 class TypeArgumentType;
 class ExtVectorType;
 class NullableType;
+class NonNullableType;
 
 /*
  * \class TypeVisitor<T>
@@ -107,5 +108,7 @@ class TypeVisitor {
   virtual T_RESULT visitTypeArgument(const ::Meta::TypeArgumentType& type) = 0;
 
   virtual T_RESULT visitNullable(const ::Meta::NullableType& type) = 0;
+
+  virtual T_RESULT visitNonNullable(const ::Meta::NonNullableType& type) = 0;
 };
 }  // namespace Meta

--- a/metadata-generator/src/Meta/ValidateMetaTypeVisitor.cpp
+++ b/metadata-generator/src/Meta/ValidateMetaTypeVisitor.cpp
@@ -171,3 +171,10 @@ bool ValidateMetaTypeVisitor::visitNullable(const NullableType& typeDetails) {
 
   return true;
 }
+
+bool ValidateMetaTypeVisitor::visitNonNullable(
+    const NonNullableType& typeDetails) {
+  typeDetails.innerType->visit(*this);
+
+  return true;
+}

--- a/metadata-generator/src/Meta/ValidateMetaTypeVisitor.h
+++ b/metadata-generator/src/Meta/ValidateMetaTypeVisitor.h
@@ -93,6 +93,8 @@ class ValidateMetaTypeVisitor : public TypeVisitor<bool> {
 
   virtual bool visitNullable(const ::Meta::NullableType& type);
 
+  virtual bool visitNonNullable(const ::Meta::NonNullableType& type);
+
  private:
   MetaFactory& _metaFactory;
 };

--- a/metadata-generator/src/TypeScript/DefinitionWriter.cpp
+++ b/metadata-generator/src/TypeScript/DefinitionWriter.cpp
@@ -949,7 +949,8 @@ bool DefinitionWriter::hasClosedGenerics(const Type& type) {
 }
 
 std::string DefinitionWriter::tsifyType(const Type& type,
-                                        const bool isFuncParam) {
+                                        const bool isFuncParam,
+                                        const bool suppressNull) {
   switch (type.getType()) {
     case TypeVoid:
       return "void";
@@ -1010,6 +1011,9 @@ std::string DefinitionWriter::tsifyType(const Type& type,
                                      tsifyType(*pointerType.innerType) + ">";
       if (isFuncParam) {
         result += " | ArrayBufferLike | ArrayBufferView";
+      }
+      if (!suppressNull) {
+        result += " | null";
       }
       return result;
     }
@@ -1130,7 +1134,15 @@ std::string DefinitionWriter::tsifyType(const Type& type,
       return type.as<TypeArgumentType>().name;
     case TypeNullable: {
       const NullableType& nullableType = type.as<NullableType>();
+      if (nullableType.innerType->is(TypePointer)) {
+        return tsifyType(*nullableType.innerType, isFuncParam);
+      }
       return tsifyType(*nullableType.innerType, isFuncParam) + " | null";
+    }
+    case TypeNonNullable: {
+      const NonNullableType& nonNullType = type.as<NonNullableType>();
+      bool suppress = isFuncParam;
+      return tsifyType(*nonNullType.innerType, isFuncParam, suppress);
     }
     case TypeVaList:
     case TypeInstancetype:

--- a/metadata-generator/src/TypeScript/DefinitionWriter.h
+++ b/metadata-generator/src/TypeScript/DefinitionWriter.h
@@ -1,87 +1,107 @@
 #pragma once
 
-#include "DocSetManager.h"
-#include "Meta/MetaEntities.h"
 #include <Meta/TypeFactory.h>
+
 #include <sstream>
 #include <string>
 #include <unordered_set>
 
+#include "DocSetManager.h"
+#include "Meta/MetaEntities.h"
+
 namespace TypeScript {
 class DefinitionWriter : Meta::MetaVisitor {
-public:
-    DefinitionWriter(std::pair<clang::Module*, std::vector<Meta::Meta*> >& module, Meta::TypeFactory& typeFactory, std::string docSetPath)
-        : _module(module)
-        , _typeFactory(typeFactory)
-        , _docSet(docSetPath)
-    {
-    }
+ public:
+  DefinitionWriter(std::pair<clang::Module*, std::vector<Meta::Meta*> >& module,
+                   Meta::TypeFactory& typeFactory, std::string docSetPath)
+      : _module(module), _typeFactory(typeFactory), _docSet(docSetPath) {}
 
-    std::string write();
-    
-    static bool applyManualChanges;
+  std::string write();
 
-    virtual void visit(Meta::InterfaceMeta* meta) override;
+  static bool applyManualChanges;
 
-    virtual void visit(Meta::ProtocolMeta* meta) override;
+  virtual void visit(Meta::InterfaceMeta* meta) override;
 
-    virtual void visit(Meta::CategoryMeta* meta) override;
+  virtual void visit(Meta::ProtocolMeta* meta) override;
 
-    virtual void visit(Meta::FunctionMeta* meta) override;
+  virtual void visit(Meta::CategoryMeta* meta) override;
 
-    virtual void visit(Meta::StructMeta* meta) override;
+  virtual void visit(Meta::FunctionMeta* meta) override;
 
-    virtual void visit(Meta::UnionMeta* meta) override;
+  virtual void visit(Meta::StructMeta* meta) override;
 
-    virtual void visit(Meta::EnumMeta* meta) override;
+  virtual void visit(Meta::UnionMeta* meta) override;
 
-    virtual void visit(Meta::VarMeta* meta) override;
+  virtual void visit(Meta::EnumMeta* meta) override;
 
-    virtual void visit(Meta::MethodMeta* meta) override;
+  virtual void visit(Meta::VarMeta* meta) override;
 
-    virtual void visit(Meta::PropertyMeta* meta) override;
+  virtual void visit(Meta::MethodMeta* meta) override;
 
-    virtual void visit(Meta::EnumConstantMeta* meta) override;
+  virtual void visit(Meta::PropertyMeta* meta) override;
 
-private:
-    template <class Member>
-    using CompoundMemberMap = std::map<std::string, std::pair<Meta::BaseClassMeta*, Member*> >;
+  virtual void visit(Meta::EnumConstantMeta* meta) override;
 
-    void writeMembers(const std::vector<Meta::RecordField>& fields, std::vector<TSComment> fieldsComments);
-    void writeProperty(Meta::PropertyMeta* meta, Meta::BaseClassMeta* owner, Meta::InterfaceMeta* target, CompoundMemberMap<Meta::PropertyMeta> compoundProperties);
+ private:
+  template <class Member>
+  using CompoundMemberMap =
+      std::map<std::string, std::pair<Meta::BaseClassMeta*, Member*> >;
 
-    static void getInheritedMembersRecursive(Meta::InterfaceMeta* interface,
-        CompoundMemberMap<Meta::MethodMeta>* staticMethods,
-        CompoundMemberMap<Meta::MethodMeta>* instanceMethods,
-        CompoundMemberMap<Meta::PropertyMeta>* staticProperties,
-        CompoundMemberMap<Meta::PropertyMeta>* instanceProperties);
+  void writeMembers(const std::vector<Meta::RecordField>& fields,
+                    std::vector<TSComment> fieldsComments);
+  void writeProperty(Meta::PropertyMeta* meta, Meta::BaseClassMeta* owner,
+                     Meta::InterfaceMeta* target,
+                     CompoundMemberMap<Meta::PropertyMeta> compoundProperties);
 
-    static void getProtocolMembersRecursive(Meta::ProtocolMeta* protocol,
-        CompoundMemberMap<Meta::MethodMeta>* staticMethods,
-        CompoundMemberMap<Meta::MethodMeta>* instanceMethods,
-        CompoundMemberMap<Meta::PropertyMeta>* staticProperties,
-        CompoundMemberMap<Meta::PropertyMeta>* instanceProperties,
-        std::unordered_set<Meta::ProtocolMeta*>& visitedProtocols);
+  static void getInheritedMembersRecursive(
+      Meta::InterfaceMeta* interface,
+      CompoundMemberMap<Meta::MethodMeta>* staticMethods,
+      CompoundMemberMap<Meta::MethodMeta>* instanceMethods,
+      CompoundMemberMap<Meta::PropertyMeta>* staticProperties,
+      CompoundMemberMap<Meta::PropertyMeta>* instanceProperties);
 
-    static std::string writeConstructor(const CompoundMemberMap<Meta::MethodMeta>::value_type& initializer,
-        const Meta::BaseClassMeta* owner);
-    static std::string writeMethod(Meta::MethodMeta* meta, Meta::BaseClassMeta* owner, bool canUseThisType = false);
-    static std::string writeMethod(CompoundMemberMap<Meta::MethodMeta>::value_type& method, Meta::BaseClassMeta* owner,
-        const std::unordered_set<Meta::ProtocolMeta*>& protocols, bool canUseThisType = false);
-    static std::string writeProperty(Meta::PropertyMeta* meta, Meta::BaseClassMeta* owner, bool optOutTypeChecking);
-    static std::string writeFunctionProto(const std::vector<Meta::Type*>& signature);
-    static std::string localizeReference(const std::string& jsName, std::string moduleName);
-    static std::string localizeReference(const Meta::Meta& meta);
-    static std::string tsifyType(const Meta::Type& type, const bool isParam = false);
-    static std::string computeMethodReturnType(const Meta::Type* retType, const Meta::BaseClassMeta* owner, bool canUseThisType = false);
-    std::string getTypeArgumentsStringOrEmpty(const clang::ObjCObjectType* objectType);
+  static void getProtocolMembersRecursive(
+      Meta::ProtocolMeta* protocol,
+      CompoundMemberMap<Meta::MethodMeta>* staticMethods,
+      CompoundMemberMap<Meta::MethodMeta>* instanceMethods,
+      CompoundMemberMap<Meta::PropertyMeta>* staticProperties,
+      CompoundMemberMap<Meta::PropertyMeta>* instanceProperties,
+      std::unordered_set<Meta::ProtocolMeta*>& visitedProtocols);
 
-    static bool hasClosedGenerics(const Meta::Type& type);
+  static std::string writeConstructor(
+      const CompoundMemberMap<Meta::MethodMeta>::value_type& initializer,
+      const Meta::BaseClassMeta* owner);
+  static std::string writeMethod(Meta::MethodMeta* meta,
+                                 Meta::BaseClassMeta* owner,
+                                 bool canUseThisType = false);
+  static std::string writeMethod(
+      CompoundMemberMap<Meta::MethodMeta>::value_type& method,
+      Meta::BaseClassMeta* owner,
+      const std::unordered_set<Meta::ProtocolMeta*>& protocols,
+      bool canUseThisType = false);
+  static std::string writeProperty(Meta::PropertyMeta* meta,
+                                   Meta::BaseClassMeta* owner,
+                                   bool optOutTypeChecking);
+  static std::string writeFunctionProto(
+      const std::vector<Meta::Type*>& signature);
+  static std::string localizeReference(const std::string& jsName,
+                                       std::string moduleName);
+  static std::string localizeReference(const Meta::Meta& meta);
+  static std::string tsifyType(const Meta::Type& type,
+                               const bool isParam = false,
+                               const bool suppressNull = false);
+  static std::string computeMethodReturnType(const Meta::Type* retType,
+                                             const Meta::BaseClassMeta* owner,
+                                             bool canUseThisType = false);
+  std::string getTypeArgumentsStringOrEmpty(
+      const clang::ObjCObjectType* objectType);
 
-    std::pair<clang::Module*, std::vector<Meta::Meta*> >& _module;
-    Meta::TypeFactory& _typeFactory;
-    DocSetManager _docSet;
-    std::unordered_set<std::string> _importedModules;
-    std::ostringstream _buffer;
+  static bool hasClosedGenerics(const Meta::Type& type);
+
+  std::pair<clang::Module*, std::vector<Meta::Meta*> >& _module;
+  Meta::TypeFactory& _typeFactory;
+  DocSetManager _docSet;
+  std::unordered_set<std::string> _importedModules;
+  std::ostringstream _buffer;
 };
-}
+}  // namespace TypeScript


### PR DESCRIPTION
## Summary

- Pointer return types now always include `| null` in generated `.d.ts` files, matching the runtime behavior where a native null pointer returns JS `null` (not an `interop.Pointer` wrapping address 0)
- Pointer parameter types include `| null` by default, except when the native API is annotated `_Nonnull` — preserving type safety for APIs that contractually require a non-null pointer
- Adds `NonNullableType` to the metadata generator's type system to track `_Nonnull` annotations from clang, mirroring the existing `NullableType` for `_Nullable`

### Before
```ts
// return — no null, but runtime can return null
declare function CFAllocatorAllocate(...): interop.Pointer | interop.Reference<any>;
// param — no null, but runtime accepts null/undefined
declare function fegetenv(p1: interop.Pointer | interop.Reference<fenv_t> | ArrayBufferLike | ArrayBufferView): number;
```

### After
```ts
// return — always nullable (runtime returns null for nullptr)
declare function CFAllocatorAllocate(...): interop.Pointer | interop.Reference<any> | null;
// unannotated/nullable param — accepts null
declare function fegetenv(p1: interop.Pointer | interop.Reference<fenv_t> | ArrayBufferLike | ArrayBufferView | null): number;
// _Nonnull param — no null (e.g. NSData.dataWithBytesNoCopyLength)
dataWithBytesNoCopyLength(bytes: interop.Pointer | interop.Reference<any> | ArrayBufferLike | ArrayBufferView, ...): NSData;
```

Array types (`interop.Reference<T>` from `ConstantArray`/`ExtVector`/`IncompleteArray`) are not affected — they represent inline data that is never null.

## Test plan

- [x] Built metadata generator for arm64
- [x] Generated declarations for 65 modules (27,718 declarations) from the iOS 18.5 SDK
- [x] Verified 20,419 pointer params have `| null` (nullable/unannotated) and 2,549 do not (`_Nonnull`)
- [x] Verified all pointer return types include `| null`
- [x] Verified array types (`interop.Reference<T>` without `interop.Pointer`) are unaffected
- [x] Spot-checked real APIs: `NSData.dataWithBytesNoCopyLength` (nonnull, no null) vs `NSData.dataWithBytesLength` (nullable, has null), `CGBitmapContextCreate(data:)` (nullable, has null)
