### PR TITLE
fix: add SharedArrayBuffer support and fix byteOffset handling across all buffer paths

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -1,11 +1,11 @@
+#include "ArgConverter.h"
 #include <Foundation/Foundation.h>
 #include <sstream>
-#include "ArgConverter.h"
-#include "NativeScriptException.h"
 #include "DictionaryAdapter.h"
-#include "ObjectManager.h"
-#include "Interop.h"
 #include "Helpers.h"
+#include "Interop.h"
+#include "NativeScriptException.h"
+#include "ObjectManager.h"
 #include "Runtime.h"
 #include "RuntimeConfig.h"
 
@@ -14,972 +14,1022 @@ using namespace std;
 
 namespace tns {
 
-void ArgConverter::Init(Local<Context> context, GenericNamedPropertyGetterCallback structPropertyGetter, GenericNamedPropertySetterCallback structPropertySetter) {
-    Isolate* isolate = context->GetIsolate();
-    auto cache = Caches::Get(isolate);
-    cache->EmptyObjCtorFunc = std::make_unique<Persistent<v8::Function>>(isolate, ArgConverter::CreateEmptyInstanceFunction(context));
-    cache->EmptyStructCtorFunc = std::make_unique<Persistent<v8::Function>>(isolate, ArgConverter::CreateEmptyInstanceFunction(context, structPropertyGetter, structPropertySetter));
+void ArgConverter::Init(Local<Context> context,
+                        GenericNamedPropertyGetterCallback structPropertyGetter,
+                        GenericNamedPropertySetterCallback structPropertySetter) {
+  Isolate* isolate = context->GetIsolate();
+  auto cache = Caches::Get(isolate);
+  cache->EmptyObjCtorFunc = std::make_unique<Persistent<v8::Function>>(
+      isolate, ArgConverter::CreateEmptyInstanceFunction(context));
+  cache->EmptyStructCtorFunc = std::make_unique<Persistent<v8::Function>>(
+      isolate, ArgConverter::CreateEmptyInstanceFunction(context, structPropertyGetter,
+                                                         structPropertySetter));
 }
 
-Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Object> receiver, V8Args& args, const MethodMeta* meta, bool isMethodCallback) {
-    Isolate* isolate = context->GetIsolate();
-    id target = nil;
-    bool instanceMethod = !receiver.IsEmpty();
-    bool callSuper = false;
-    if (instanceMethod) {
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
-        
-        if (wrapper == nullptr) {
-            // During fast view churn like HMR in development, JS objects can outlive their
-            // native wrappers briefly. In Debug, throw a catchable JS error instead of crashing.
-            // In Release, assert so crash reporting can capture unexpected cases.
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                std::string errMsg = std::string("Cannot call method '") + jsNameStr +
-                    "' on a disposed native object (class: " + classNameStr +
-                    ", selector: " + selectorStr + "). This can happen during HMR or fast view churn.";
-                throw NativeScriptException(isolate, errMsg);
-            } else {
-                tns::Assert(false, isolate);
-            }
-        }
-
-        if (wrapper->Type() == WrapperType::ObjCAllocObject) {
-            ObjCAllocDataWrapper* allocWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
-            Class klass = allocWrapper->Klass();
-            target = [klass alloc];
-        } else if (wrapper->Type() == WrapperType::ObjCObject) {
-            ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-            target = objcWrapper->Data();
-
-            std::string className = object_getClassName(target);
-            auto cache = Caches::Get(isolate);
-            auto it = cache->ClassPrototypes.find(className);
-            // For extended classes we will call the base method
-            callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
-        } else {
-            if (RuntimeConfig.IsDebug) {
-                const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
-                const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
-                const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
-                std::string errMsg = std::string("Unexpected receiver wrapper type ") +
-                    std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
-                    "' (class: " + classNameStr + ", selector: " + selectorStr +
-                    "). This can happen during HMR or fast view churn.";
-                throw NativeScriptException(isolate, errMsg);
-            } else {
-                tns::Assert(false, isolate);
-            }
-        }
-    }
-
-    if (args.Length() != meta->encodings()->count - 1) {
-        // Arguments number mismatch -> search for a possible method overload in the class hierarchy
-        std::string methodName = meta->jsName();
-        std::string className = class_getName(klass);
-        MemberType type = instanceMethod ? MemberType::InstanceMethod : MemberType::StaticMethod;
-        std::vector<const MethodMeta*> overloads;
-        ArgConverter::FindMethodOverloads(klass, methodName, type, overloads);
-        if (overloads.size() > 0) {
-            for (auto it = overloads.begin(); it != overloads.end(); it++) {
-                const MethodMeta* methodMeta = (*it);
-                if (args.Length() == methodMeta->encodings()->count - 1) {
-                    meta = methodMeta;
-                    break;
-                }
-            }
-        }
-    }
-
-    int argsCount = meta->encodings()->count - 1;
-    if ((!meta->hasErrorOutParameter() && args.Length() != argsCount) ||
-        (meta->hasErrorOutParameter() && args.Length() != argsCount && args.Length() != argsCount - 1)) {
-        std::ostringstream errorStream;
-        errorStream << "Actual arguments count: \"" << argsCount << ". Expected: \"" << args.Length() << "\".";
-        std::string errorMessage = errorStream.str();
-        throw NativeScriptException(errorMessage);
-    }
-
-    ObjCMethodCall methodCall(context, meta, target, klass, args, callSuper);
-    return Interop::CallFunction(methodCall);
-}
-
-Local<Value> ArgConverter::ConvertArgument(Local<Context> context, BaseDataWrapper* wrapper, bool skipGCRegistration, const std::vector<std::string>& additionalProtocols) {
-    Isolate* isolate = context->GetIsolate();
-    if (wrapper == nullptr) {
-        return Null(isolate);
-    }
-
-    Local<Value> result = CreateJsWrapper(context, wrapper, Local<Object>(), skipGCRegistration, additionalProtocols);
-    return result;
-}
-
-void ArgConverter::MethodCallback(ffi_cif* cif, void* retValue, void** argValues, void* userData) {
-    MethodCallbackWrapper* data = static_cast<MethodCallbackWrapper*>(userData);
-
-    Isolate* isolate = data->isolateWrapper_.Isolate();
-
-    if (!data->isolateWrapper_.IsValid()) {
-        memset(retValue, 0, cif->rtype->size);
-        return;
-    }
-
-    v8::Locker locker(isolate);
-    Isolate::Scope isolate_scope(isolate);
-    HandleScope handle_scope(isolate);
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-
-    Local<Context> context = cache->GetContext();
-    Context::Scope context_scope(context);
-    std::shared_ptr<Persistent<Value>> poCallback = data->callback_;
-
-    bool hasErrorOutParameter = false;
-
-    std::vector<Local<Value>> v8Args;
-    v8Args.reserve(data->paramsCount_);
-    const TypeEncoding* typeEncoding = data->typeEncoding_;
-    for (int i = 0; i < data->paramsCount_; i++) {
-        typeEncoding = typeEncoding->next();
-        if (i == data->paramsCount_ - 1 && ArgConverter::IsErrorOutParameter(typeEncoding)) {
-            hasErrorOutParameter = true;
-            // No need to provide the NSError** parameter to the javascript callback
-            continue;
-        }
-
-        int argIndex = i + data->initialParamIndex_;
-
-        uint8_t* argBuffer = (uint8_t*)argValues[argIndex];
-        BaseCall call(argBuffer);
-        Local<Value> jsWrapper = Interop::GetResult(context, typeEncoding, &call, true);
-
-        if (!jsWrapper.IsEmpty()) {
-            v8Args.push_back(jsWrapper);
-        } else {
-            v8Args.push_back(v8::Undefined(isolate));
-        }
-    }
-
-    Local<Object> thiz = context->Global();
-    if (data->initialParamIndex_ > 1) {
-        id self_ = *static_cast<const id*>(argValues[0]);
-        auto it = cache->Instances.find(self_);
-        if (it != cache->Instances.end()) {
-            thiz = it->second->Get(data->isolateWrapper_.Isolate()).As<Object>();
-        } else {
-            ObjCDataWrapper* wrapper = new ObjCDataWrapper(self_);
-            thiz = ArgConverter::CreateJsWrapper(context, wrapper, Local<Object>(), true).As<Object>();
-            tns::DeleteWrapperIfUnused(isolate, thiz, wrapper);
-        }
-    }
-
-    Local<Value> result;
-    Local<v8::Function> callback = poCallback->Get(isolate).As<v8::Function>();
-
-    bool success = false;
-    if (hasErrorOutParameter) {
-        // We don't want the global error handler (NativeScriptException::OnUncaughtError) to be called for javascript exceptions occuring inside
-        // methods that have NSError* parameters. Those js errors will be marshalled to NSError* and sent
-        // directly to the calling native code. The v8::TryCatch statement prevents the global handler to be called.
-        TryCatch tc(isolate);
-        success = callback->Call(context, thiz, (int)v8Args.size(), v8Args.data()).ToLocal(&result);
-        if (!success && tc.HasCaught()) {
-            Local<Value> exception = tc.Exception();
-            std::string message = tns::ToString(isolate, exception);
-
-            int errorParamIndex = data->initialParamIndex_ + data->paramsCount_ - 1;
-            void* errorParam = argValues[errorParamIndex];
-            NSError*__strong** outPtr = static_cast<NSError*__strong**>(errorParam);
-            if (outPtr && *outPtr) {
-                NSError* error = [NSError errorWithDomain:@"TNSErrorDomain" code:164 userInfo:@{ @"TNSJavaScriptError": tns::ToNSString(message) }];
-                **static_cast<NSError*__strong**>(outPtr) = error;
-            }
-        }
-    } else {
-        success = callback->Call(context, thiz, (int)v8Args.size(), v8Args.data()).ToLocal(&result);
-    }
-
-    if (!success) {
-        memset(retValue, 0, cif->rtype->size);
-        return;
-    }
-
-    ArgConverter::SetValue(context, retValue, result, data->typeEncoding_);
-}
-
-void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value> value, const TypeEncoding* typeEncoding) {
-    if (typeEncoding->type == BinaryTypeEncodingType::VoidEncoding) {
-        return;
-    }
-
-    if (value.IsEmpty() || value->IsNullOrUndefined()) {
-        void* nullPtr = nullptr;
-        *(ffi_arg *)retValue = (unsigned long)nullPtr;
-        return;
-    }
-
-    Isolate* isolate = context->GetIsolate();
-
-    // TODO: Refactor this to reuse some existing logic in Interop::SetFFIParams
-    BinaryTypeEncodingType type = typeEncoding->type;
-
-    if (tns::IsBool(value)) {
-        bool boolValue = value.As<v8::Boolean>()->Value();
-        *(ffi_arg *)retValue = (bool)boolValue;
-        return;
-    } else if (tns::IsNumber(value)) {
-        double numValue = tns::ToNumber(isolate, value);
-        switch (type) {
-            case BinaryTypeEncodingType::UShortEncoding: {
-                *static_cast<unsigned short*>(retValue) = (unsigned short)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::ShortEncoding: {
-                *static_cast<short*>(retValue) = (short)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::UIntEncoding: {
-                *static_cast<unsigned int*>(retValue) = (unsigned int)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::IntEncoding: {
-                *static_cast<int*>(retValue) = (int)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::ULongEncoding: {
-                *static_cast<unsigned long*>(retValue) = (unsigned long)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::LongEncoding: {
-                *static_cast<long*>(retValue) = (long)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::ULongLongEncoding: {
-                *static_cast<unsigned long long*>(retValue) = (unsigned long long)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::LongLongEncoding: {
-                *static_cast<long long*>(retValue) = (long long)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::FloatEncoding: {
-                *static_cast<float*>(retValue) = (float)numValue;
-                return;
-            }
-            case BinaryTypeEncodingType::DoubleEncoding: {
-                *static_cast<double*>(retValue) = numValue;
-                return;
-            }
-            default:
-                return;
-        }
-    } else if (value->IsString()) {
-        if (type == BinaryTypeEncodingType::IdEncoding ||
-            type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-            id data = tns::ToNSString(isolate, value);
-            // this feels wrong but follows the other CFBridgingRetain calls
-            // and also solves a leak
-            auto ref = CFBridgingRetain(data);
-            *(CFTypeRef*)retValue = ref;
-            CFRelease(ref);
-            return;
-        }
-    } else if (value->IsObject()) {
-        if (type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
-            type == BinaryTypeEncodingType::InstanceTypeEncoding ||
-            type == BinaryTypeEncodingType::IdEncoding) {
-            BaseDataWrapper* baseWrapper = tns::GetValue(isolate, value);
-            if (baseWrapper != nullptr && baseWrapper->Type() == WrapperType::ObjCObject) {
-                ObjCDataWrapper* wrapper = static_cast<ObjCDataWrapper*>(baseWrapper);
-                id data = wrapper->Data();
-                memset(retValue, 0, sizeof(id));
-                *static_cast<id __strong *>(retValue) = data;
-                return;
-            } else {
-                id adapter = [[DictionaryAdapter alloc] initWithJSObject:value.As<Object>() isolate:isolate];
-                memset(retValue, 0, sizeof(id));
-                *static_cast<id __strong *>(retValue) = adapter;
-                // CFAutorelease(adapter);
-                return;
-            }
-        } else if (type == BinaryTypeEncodingType::StructDeclarationReference) {
-            BaseDataWrapper* baseWrapper = tns::GetValue(isolate, value);
-            if (baseWrapper == nullptr) {
-                const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
-                const Meta* meta = ArgConverter::GetMeta(structName);
-                tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
-                const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
-                StructInfo structInfo = FFICall::GetStructInfo(structMeta);
-                Interop::InitializeStruct(context, retValue, structInfo.Fields(), value);
-                return;
-            } else if (baseWrapper->Type() == WrapperType::Struct) {
-                StructWrapper* structWrapper = static_cast<StructWrapper*>(baseWrapper);
-                size_t size = structWrapper->StructInfo().FFIType()->size;
-                void* data = structWrapper->Data();
-                memcpy(retValue, data, size);
-                return;
-            }
-        }
-    }
-
-    // TODO: Handle other return types, i.e. assign the retValue parameter from the v8 result
-    tns::Assert(false, isolate);
-}
-
-void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbackInfo<Value>& info, Class klass, const InterfaceMeta* interfaceMeta) {
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(klass != nullptr, isolate);
-
-    id result = nil;
-
-    if (info.Length() == 1) {
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, info[0]);
-        if (wrapper != nullptr && wrapper->Type() == WrapperType::Pointer) {
-            PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-            result = CFBridgingRelease(pointerWrapper->Data());
-        }
-    }
-
-    if (result == nil && interfaceMeta == nullptr) {
-        const Meta* meta = ArgConverter::FindMeta(klass);
-        if (meta != nullptr && meta->type() == MetaType::Interface) {
-            interfaceMeta = static_cast<const InterfaceMeta*>(meta);
-        }
-    }
-
-    if (result == nil && interfaceMeta != nullptr && info.Length() > 0) {
-        std::vector<Local<Value>> args;
-        const MethodMeta* initializer = ArgConverter::FindInitializer(context, klass, interfaceMeta, info, args);
-        result = [klass alloc];
-
-        V8VectorArgs vectorArgs(args);
-        result = Interop::CallInitializer(context, initializer, result, klass, vectorArgs);
-    }
-
-    if (result == nil) {
-        result = [[klass alloc] init];
-    }
-
-    auto cache = Caches::Get(isolate);
-    auto it = cache->Instances.find(result);
-    if (it != cache->Instances.end()) {
-        Local<Value> obj = it->second->Get(isolate);
-        info.GetReturnValue().Set(obj);
-    } else {
-        ObjCDataWrapper* wrapper = new ObjCDataWrapper(result);
-        Local<Object> thiz = info.This();
-        Local<Context> context = cache->GetContext();
-        tns::SetValue(isolate, thiz, wrapper);
-        std::shared_ptr<Persistent<Value>> poThiz = ObjectManager::Register(context, thiz);
-        cache->Instances.emplace(result, poThiz);
-        // [result retain];
-    }
-}
-
-const MethodMeta* ArgConverter::FindInitializer(Local<Context> context, Class klass, const InterfaceMeta* interfaceMeta, const FunctionCallbackInfo<Value>& info, std::vector<Local<Value>>& args) {
-    Isolate* isolate = context->GetIsolate();
-    std::vector<const MethodMeta*> candidates;
-    args = tns::ArgsToVector(info);
-    std::vector<Local<Value>> initializerArgs;
-    std::string constructorTokens;
-    if (info.Length() == 1 && info[0]->IsObject() && tns::GetValue(isolate, info[0]) == nullptr) {
-        initializerArgs = GetInitializerArgs(info[0].As<Object>(), constructorTokens);
-    }
-
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-    bool found = false;
-    do {
-        std::vector<const MethodMeta*> initializers = ArgConverter::GetInitializers(cache.get(), klass, interfaceMeta);
-        for (const MethodMeta* candidate: initializers) {
-            if (constructorTokens != "") {
-                const char* expectedTokens = candidate->constructorTokens();
-                if (strcmp(expectedTokens, constructorTokens.c_str()) == 0) {
-                    candidates.clear();
-                    candidates.push_back(candidate);
-                    args = initializerArgs;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (ArgConverter::CanInvoke(context, candidate, info)) {
-                candidates.push_back(candidate);
-            }
-        }
-
-        if (found) {
-            break;
-        }
-
-        interfaceMeta = interfaceMeta->baseMeta();
-    } while (interfaceMeta);
-
-    if (candidates.size() == 0) {
-        throw NativeScriptException("No initializer found that matches constructor invocation.");
-    } else if (candidates.size() > 1) {
-        if (info.Length() == 0) {
-            auto it = std::find_if(candidates.begin(), candidates.end(), [](const MethodMeta* c) -> bool { return strcmp(c->name(), "init") == 0; });
-            if (it != candidates.end()) {
-                return (*it);
-            }
-        }
-
-        std::stringstream ss;
-        ss << "More than one initializer found that matches constructor invocation:";
-        for (int i = 0; i < candidates.size(); i++) {
-            ss << " ";
-            ss << candidates[i]->selectorAsString();
-        }
-        std::string errorMessage = ss.str();
-        throw NativeScriptException(errorMessage);
-    }
-
-    return candidates[0];
-}
-
-bool ArgConverter::CanInvoke(Local<Context> context, const MethodMeta* candidate, const FunctionCallbackInfo<Value>& info) {
-    if (candidate->encodings()->count - 1 != info.Length()) {
-        return false;
-    }
-
-    if (info.Length() == 0) {
-        return true;
-    }
-
-    const TypeEncoding* typeEncoding = candidate->encodings()->first();
-    for (int i = 0; i < info.Length(); i++) {
-        typeEncoding = typeEncoding->next();
-        Local<Value> arg = info[i];
-
-        if (!CanInvoke(context, typeEncoding, arg)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool ArgConverter::CanInvoke(Local<Context> context, const TypeEncoding* typeEncoding, Local<Value> arg) {
-    if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
-        return true;
-    }
-
-    Isolate* isolate = context->GetIsolate();
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-        const char* name = typeEncoding->details.declarationReference.name.valuePtr();
-        if (strcmp(name, "NSNumber") == 0 && tns::IsNumber(arg)) {
-            return true;
-        }
-
-        if (strcmp(name, "NSString") == 0 && tns::IsString(arg)) {
-            return true;
-        }
-
-        if (strcmp(name, "NSArray") == 0 && arg->IsArray()) {
-            return true;
-        }
-
-        if (BaseDataWrapper* wrapper = tns::GetValue(isolate, arg)) {
-            if (wrapper->Type() == WrapperType::ObjCObject) {
-                ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                Class candidateClass = objc_getClass(name);
-                if (candidateClass != nil && [objcWrapper->Data() isKindOfClass:candidateClass]) {
-                    return true;
-                }
-            }
-        }
-    }
-
-    if (typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
-        return arg->IsObject();
-    }
-
-    if (tns::IsBool(arg)) {
-        return typeEncoding->type == BinaryTypeEncodingType::BoolEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::IdEncoding;
-    }
-
-    if (tns::IsNumber(arg)) {
-        return typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::UShortEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::ShortEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::UIntEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::IntEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::ULongEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::LongEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::ULongLongEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::LongLongEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::FloatEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::DoubleEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::UCharEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::CharEncoding;
-    }
-
-    if (tns::IsString(arg)) {
-        return typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::UnicharEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::CStringEncoding;
-    }
-
-    if (arg->IsFunction()) {
-        return typeEncoding->type == BinaryTypeEncodingType::BlockEncoding ||
-            typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding;
-    }
-
-    if (arg->IsArrayBuffer() || arg->IsArrayBufferView()) {
-        return typeEncoding->type == BinaryTypeEncodingType::IncompleteArrayEncoding;
-    }
-
-    return false;
-}
-
-std::vector<Local<Value>> ArgConverter::GetInitializerArgs(Local<Object> obj, std::string& constructorTokens) {
-    std::vector<Local<Value>> args;
-    constructorTokens = "";
-    Local<Context> context;
-    bool success = obj->GetCreationContext().ToLocal(&context);
-    tns::Assert(success);
-    Isolate* isolate = context->GetIsolate();
-    Local<v8::Array> properties;
-    if (obj->GetOwnPropertyNames(context).ToLocal(&properties)) {
-        std::stringstream ss;
-        for (uint32_t i = 0; i < properties->Length(); i++) {
-            Local<Value> propertyName;
-            if (properties->Get(context, i).ToLocal(&propertyName)) {
-                std::string name = tns::ToString(isolate, propertyName);
-                ss << name << ":";
-                Local<Value> propertyValue;
-                bool ok = obj->Get(context, propertyName).ToLocal(&propertyValue);
-                tns::Assert(ok, isolate);
-                args.push_back(propertyValue);
-            }
-        }
-        constructorTokens = ss.str();
-    }
-
-    return args;
-}
-
-Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapper* wrapper, Local<Object> receiver, bool skipGCRegistration, const std::vector<std::string>& additionalProtocols) {
-    Isolate* isolate = context->GetIsolate();
+Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Object> receiver,
+                                  V8Args& args, const MethodMeta* meta, bool isMethodCallback) {
+  Isolate* isolate = context->GetIsolate();
+  id target = nil;
+  bool instanceMethod = !receiver.IsEmpty();
+  bool callSuper = false;
+  if (instanceMethod) {
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
 
     if (wrapper == nullptr) {
-        return Null(isolate);
-    }
-
-    if (wrapper->Type() == WrapperType::Struct) {
-        if (receiver.IsEmpty()) {
-            std::shared_ptr<Persistent<Value>> poStruct = CreateEmptyStruct(context);
-            receiver = poStruct->Get(isolate).As<Object>();
-        }
-
-        StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-        StructInfo structInfo = structWrapper->StructInfo();
-        auto cache = Caches::Get(isolate);
-        Local<v8::Function> structCtorFunc = cache->StructCtorInitializer(context, structInfo);
-        Local<Value> proto;
-        bool success = structCtorFunc->Get(context, tns::ToV8String(isolate, "prototype")).ToLocal(&proto);
-
-        if (success && !proto.IsEmpty()) {
-            success = receiver->SetPrototype(context, proto).FromMaybe(false);
-            tns::Assert(success, isolate);
-        }
-
-        tns::SetValue(isolate, receiver, structWrapper);
-
-        return receiver;
+      // During fast view churn like HMR in development, JS objects can outlive their
+      // native wrappers briefly. In Debug, throw a catchable JS error instead of crashing.
+      // In Release, assert so crash reporting can capture unexpected cases.
+      if (RuntimeConfig.IsDebug) {
+        const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
+        const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
+        const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
+        std::string errMsg = std::string("Cannot call method '") + jsNameStr +
+                             "' on a disposed native object (class: " + classNameStr +
+                             ", selector: " + selectorStr +
+                             "). This can happen during HMR or fast view churn.";
+        throw NativeScriptException(isolate, errMsg);
+      } else {
+        tns::Assert(false, isolate);
+      }
     }
 
     if (wrapper->Type() == WrapperType::ObjCAllocObject) {
-        ObjCAllocDataWrapper* allocDataWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
-        Class klass = allocDataWrapper->Klass();
+      ObjCAllocDataWrapper* allocWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
+      Class klass = allocWrapper->Klass();
+      target = [klass alloc];
+    } else if (wrapper->Type() == WrapperType::ObjCObject) {
+      ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+      target = objcWrapper->Data();
 
-        std::shared_ptr<Persistent<Value>> poValue = CreateEmptyObject(context, false);
-        receiver = poValue->Get(isolate).As<Object>();
-
-        const Meta* meta = FindMeta(klass);
-        if (meta != nullptr) {
-            auto cache = Caches::Get(isolate);
-            KnownUnknownClassPair pair(objc_getClass(meta->name()));
-            std::vector<std::string> emptyProtocols;
-            cache->ObjectCtorInitializer(context, static_cast<const BaseClassMeta*>(meta), pair, emptyProtocols);
-            auto it = cache->Prototypes.find(meta);
-            if (it != cache->Prototypes.end()) {
-                Local<Value> prototype = it->second->Get(isolate);
-                bool success;
-                if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
-                    tns::Assert(false, isolate);
-                }
-            }
-        }
-
-        tns::SetValue(isolate, receiver, wrapper);
-
-        return receiver;
-    }
-
-    id target = nil;
-    const TypeEncoding* typeEncoding = nullptr;
-    if (wrapper->Type() == WrapperType::ObjCObject) {
-        ObjCDataWrapper* dataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-        target = dataWrapper->Data();
-        typeEncoding = dataWrapper->TypeEncoding();
-    }
-
-    if (target == nil) {
-        return Null(isolate);
-    }
-
-    auto cache = Caches::Get(isolate);
-    if (receiver.IsEmpty()) {
-        auto it = cache->Instances.find(target);
-        if (it != cache->Instances.end()) {
-            receiver = it->second->Get(isolate).As<Object>();
-        } else {
-            std::shared_ptr<Persistent<Value>> poValue = CreateEmptyObject(context, skipGCRegistration);
-            receiver = poValue->Get(isolate).As<Object>();
-            tns::SetValue(isolate, receiver, wrapper);
-            cache->Instances.emplace(target, poValue);
-            [target retain];
-        }
+      std::string className = object_getClassName(target);
+      auto cache = Caches::Get(isolate);
+      auto it = cache->ClassPrototypes.find(className);
+      // For extended classes we will call the base method
+      callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
     } else {
-        tns::SetValue(isolate, receiver, wrapper);
+      if (RuntimeConfig.IsDebug) {
+        const char* selectorStr = meta ? meta->selectorAsString() : "<unknown>";
+        const char* jsNameStr = meta ? meta->jsName() : "<unknown>";
+        const char* classNameStr = klass ? class_getName(klass) : "<unknown>";
+        std::string errMsg = std::string("Unexpected receiver wrapper type ") +
+                             std::to_string((int)wrapper->Type()) + " for method '" + jsNameStr +
+                             "' (class: " + classNameStr + ", selector: " + selectorStr +
+                             "). This can happen during HMR or fast view churn.";
+        throw NativeScriptException(isolate, errMsg);
+      } else {
+        tns::Assert(false, isolate);
+      }
     }
+  }
 
-    Class klass = [target class];
-    const Meta* meta = FindMeta(klass, typeEncoding);
-    if (meta != nullptr) {
-        std::string className = object_getClassName(target);
-        auto it = cache->ClassPrototypes.find(className);
-        if (it != cache->ClassPrototypes.end()) {
-            // for debugging rlv cell handling:
-            // NSString* message = [NSString stringWithFormat:@"ArgConverter::CreateJsWrapper FindMeta: class {%@}", NSStringFromClass(klass)];
-            // Log(@"%@", message);
-            Local<Value> prototype = it->second->Get(isolate);
-            bool success;
-            if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
-                tns::Assert(false, isolate);
-            }
-        } else {
-            Class knownClass = objc_getClass(meta->name());
-            KnownUnknownClassPair pair(knownClass, klass);
-            Local<FunctionTemplate> ctorFuncTemplate = cache->ObjectCtorInitializer(context, static_cast<const BaseClassMeta*>(meta), pair, additionalProtocols);
-            Local<v8::Function> ctorFunc;
-            bool success = ctorFuncTemplate->GetFunction(context).ToLocal(&ctorFunc);
-            tns::Assert(success, isolate);
-
-            Local<Value> prototypeValue;
-            success = ctorFunc->Get(context, tns::ToV8String(isolate, "prototype")).ToLocal(&prototypeValue);
-            tns::Assert(success, isolate);
-            Local<Object> prototype = prototypeValue.As<Object>();
-
-            if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
-                tns::Assert(false, isolate);
-            }
+  if (args.Length() != meta->encodings()->count - 1) {
+    // Arguments number mismatch -> search for a possible method overload in the class hierarchy
+    std::string methodName = meta->jsName();
+    std::string className = class_getName(klass);
+    MemberType type = instanceMethod ? MemberType::InstanceMethod : MemberType::StaticMethod;
+    std::vector<const MethodMeta*> overloads;
+    ArgConverter::FindMethodOverloads(klass, methodName, type, overloads);
+    if (overloads.size() > 0) {
+      for (auto it = overloads.begin(); it != overloads.end(); it++) {
+        const MethodMeta* methodMeta = (*it);
+        if (args.Length() == methodMeta->encodings()->count - 1) {
+          meta = methodMeta;
+          break;
         }
+      }
+    }
+  }
+
+  int argsCount = meta->encodings()->count - 1;
+  if ((!meta->hasErrorOutParameter() && args.Length() != argsCount) ||
+      (meta->hasErrorOutParameter() && args.Length() != argsCount &&
+       args.Length() != argsCount - 1)) {
+    std::ostringstream errorStream;
+    errorStream << "Actual arguments count: \"" << argsCount << ". Expected: \"" << args.Length()
+                << "\".";
+    std::string errorMessage = errorStream.str();
+    throw NativeScriptException(errorMessage);
+  }
+
+  ObjCMethodCall methodCall(context, meta, target, klass, args, callSuper);
+  return Interop::CallFunction(methodCall);
+}
+
+Local<Value> ArgConverter::ConvertArgument(Local<Context> context, BaseDataWrapper* wrapper,
+                                           bool skipGCRegistration,
+                                           const std::vector<std::string>& additionalProtocols) {
+  Isolate* isolate = context->GetIsolate();
+  if (wrapper == nullptr) {
+    return Null(isolate);
+  }
+
+  Local<Value> result =
+      CreateJsWrapper(context, wrapper, Local<Object>(), skipGCRegistration, additionalProtocols);
+  return result;
+}
+
+void ArgConverter::MethodCallback(ffi_cif* cif, void* retValue, void** argValues, void* userData) {
+  MethodCallbackWrapper* data = static_cast<MethodCallbackWrapper*>(userData);
+
+  Isolate* isolate = data->isolateWrapper_.Isolate();
+
+  if (!data->isolateWrapper_.IsValid()) {
+    memset(retValue, 0, cif->rtype->size);
+    return;
+  }
+
+  v8::Locker locker(isolate);
+  Isolate::Scope isolate_scope(isolate);
+  HandleScope handle_scope(isolate);
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+
+  Local<Context> context = cache->GetContext();
+  Context::Scope context_scope(context);
+  std::shared_ptr<Persistent<Value>> poCallback = data->callback_;
+
+  bool hasErrorOutParameter = false;
+
+  std::vector<Local<Value>> v8Args;
+  v8Args.reserve(data->paramsCount_);
+  const TypeEncoding* typeEncoding = data->typeEncoding_;
+  for (int i = 0; i < data->paramsCount_; i++) {
+    typeEncoding = typeEncoding->next();
+    if (i == data->paramsCount_ - 1 && ArgConverter::IsErrorOutParameter(typeEncoding)) {
+      hasErrorOutParameter = true;
+      // No need to provide the NSError** parameter to the javascript callback
+      continue;
     }
 
-    Class metaClass = object_getClass(target);
-    if (class_isMetaClass(metaClass)) {
-        if (tns::GetValue(isolate, receiver) == nullptr) {
-            ObjCClassWrapper* wrapper = new ObjCClassWrapper(klass);
-            tns::SetValue(isolate, receiver, wrapper);
-        }
+    int argIndex = i + data->initialParamIndex_;
+
+    uint8_t* argBuffer = (uint8_t*)argValues[argIndex];
+    BaseCall call(argBuffer);
+    Local<Value> jsWrapper = Interop::GetResult(context, typeEncoding, &call, true);
+
+    if (!jsWrapper.IsEmpty()) {
+      v8Args.push_back(jsWrapper);
+    } else {
+      v8Args.push_back(v8::Undefined(isolate));
     }
+  }
+
+  Local<Object> thiz = context->Global();
+  if (data->initialParamIndex_ > 1) {
+    id self_ = *static_cast<const id*>(argValues[0]);
+    auto it = cache->Instances.find(self_);
+    if (it != cache->Instances.end()) {
+      thiz = it->second->Get(data->isolateWrapper_.Isolate()).As<Object>();
+    } else {
+      ObjCDataWrapper* wrapper = new ObjCDataWrapper(self_);
+      thiz = ArgConverter::CreateJsWrapper(context, wrapper, Local<Object>(), true).As<Object>();
+      tns::DeleteWrapperIfUnused(isolate, thiz, wrapper);
+    }
+  }
+
+  Local<Value> result;
+  Local<v8::Function> callback = poCallback->Get(isolate).As<v8::Function>();
+
+  bool success = false;
+  if (hasErrorOutParameter) {
+    // We don't want the global error handler (NativeScriptException::OnUncaughtError) to be called
+    // for javascript exceptions occuring inside methods that have NSError* parameters. Those js
+    // errors will be marshalled to NSError* and sent directly to the calling native code. The
+    // v8::TryCatch statement prevents the global handler to be called.
+    TryCatch tc(isolate);
+    success = callback->Call(context, thiz, (int)v8Args.size(), v8Args.data()).ToLocal(&result);
+    if (!success && tc.HasCaught()) {
+      Local<Value> exception = tc.Exception();
+      std::string message = tns::ToString(isolate, exception);
+
+      int errorParamIndex = data->initialParamIndex_ + data->paramsCount_ - 1;
+      void* errorParam = argValues[errorParamIndex];
+      NSError* __strong** outPtr = static_cast<NSError * __strong**>(errorParam);
+      if (outPtr && *outPtr) {
+        NSError* error =
+            [NSError errorWithDomain:@"TNSErrorDomain"
+                                code:164
+                            userInfo:@{@"TNSJavaScriptError" : tns::ToNSString(message)}];
+        **static_cast<NSError * __strong**>(outPtr) = error;
+      }
+    }
+  } else {
+    success = callback->Call(context, thiz, (int)v8Args.size(), v8Args.data()).ToLocal(&result);
+  }
+
+  if (!success) {
+    memset(retValue, 0, cif->rtype->size);
+    return;
+  }
+
+  ArgConverter::SetValue(context, retValue, result, data->typeEncoding_);
+}
+
+void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value> value,
+                            const TypeEncoding* typeEncoding) {
+  if (typeEncoding->type == BinaryTypeEncodingType::VoidEncoding) {
+    return;
+  }
+
+  if (value.IsEmpty() || value->IsNullOrUndefined()) {
+    void* nullPtr = nullptr;
+    *(ffi_arg*)retValue = (unsigned long)nullPtr;
+    return;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+
+  // TODO: Refactor this to reuse some existing logic in Interop::SetFFIParams
+  BinaryTypeEncodingType type = typeEncoding->type;
+
+  if (tns::IsBool(value)) {
+    bool boolValue = value.As<v8::Boolean>()->Value();
+    *(ffi_arg*)retValue = (bool)boolValue;
+    return;
+  } else if (tns::IsNumber(value)) {
+    double numValue = tns::ToNumber(isolate, value);
+    switch (type) {
+      case BinaryTypeEncodingType::UShortEncoding: {
+        *static_cast<unsigned short*>(retValue) = (unsigned short)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::ShortEncoding: {
+        *static_cast<short*>(retValue) = (short)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::UIntEncoding: {
+        *static_cast<unsigned int*>(retValue) = (unsigned int)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::IntEncoding: {
+        *static_cast<int*>(retValue) = (int)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::ULongEncoding: {
+        *static_cast<unsigned long*>(retValue) = (unsigned long)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::LongEncoding: {
+        *static_cast<long*>(retValue) = (long)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::ULongLongEncoding: {
+        *static_cast<unsigned long long*>(retValue) = (unsigned long long)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::LongLongEncoding: {
+        *static_cast<long long*>(retValue) = (long long)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::FloatEncoding: {
+        *static_cast<float*>(retValue) = (float)numValue;
+        return;
+      }
+      case BinaryTypeEncodingType::DoubleEncoding: {
+        *static_cast<double*>(retValue) = numValue;
+        return;
+      }
+      default:
+        return;
+    }
+  } else if (value->IsString()) {
+    if (type == BinaryTypeEncodingType::IdEncoding ||
+        type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+      id data = tns::ToNSString(isolate, value);
+      // this feels wrong but follows the other CFBridgingRetain calls
+      // and also solves a leak
+      auto ref = CFBridgingRetain(data);
+      *(CFTypeRef*)retValue = ref;
+      CFRelease(ref);
+      return;
+    }
+  } else if (value->IsObject()) {
+    if (type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+        type == BinaryTypeEncodingType::InstanceTypeEncoding ||
+        type == BinaryTypeEncodingType::IdEncoding) {
+      BaseDataWrapper* baseWrapper = tns::GetValue(isolate, value);
+      if (baseWrapper != nullptr && baseWrapper->Type() == WrapperType::ObjCObject) {
+        ObjCDataWrapper* wrapper = static_cast<ObjCDataWrapper*>(baseWrapper);
+        id data = wrapper->Data();
+        memset(retValue, 0, sizeof(id));
+        *static_cast<id __strong*>(retValue) = data;
+        return;
+      } else {
+        id adapter = [[DictionaryAdapter alloc] initWithJSObject:value.As<Object>()
+                                                         isolate:isolate];
+        memset(retValue, 0, sizeof(id));
+        *static_cast<id __strong*>(retValue) = adapter;
+        // CFAutorelease(adapter);
+        return;
+      }
+    } else if (type == BinaryTypeEncodingType::StructDeclarationReference) {
+      BaseDataWrapper* baseWrapper = tns::GetValue(isolate, value);
+      if (baseWrapper == nullptr) {
+        const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
+        const Meta* meta = ArgConverter::GetMeta(structName);
+        tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
+        const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
+        StructInfo structInfo = FFICall::GetStructInfo(structMeta);
+        Interop::InitializeStruct(context, retValue, structInfo.Fields(), value);
+        return;
+      } else if (baseWrapper->Type() == WrapperType::Struct) {
+        StructWrapper* structWrapper = static_cast<StructWrapper*>(baseWrapper);
+        size_t size = structWrapper->StructInfo().FFIType()->size;
+        void* data = structWrapper->Data();
+        memcpy(retValue, data, size);
+        return;
+      }
+    }
+  }
+
+  // TODO: Handle other return types, i.e. assign the retValue parameter from the v8 result
+  tns::Assert(false, isolate);
+}
+
+void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbackInfo<Value>& info,
+                                   Class klass, const InterfaceMeta* interfaceMeta) {
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(klass != nullptr, isolate);
+
+  id result = nil;
+
+  if (info.Length() == 1) {
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, info[0]);
+    if (wrapper != nullptr && wrapper->Type() == WrapperType::Pointer) {
+      PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+      result = CFBridgingRelease(pointerWrapper->Data());
+    }
+  }
+
+  if (result == nil && interfaceMeta == nullptr) {
+    const Meta* meta = ArgConverter::FindMeta(klass);
+    if (meta != nullptr && meta->type() == MetaType::Interface) {
+      interfaceMeta = static_cast<const InterfaceMeta*>(meta);
+    }
+  }
+
+  if (result == nil && interfaceMeta != nullptr && info.Length() > 0) {
+    std::vector<Local<Value>> args;
+    const MethodMeta* initializer =
+        ArgConverter::FindInitializer(context, klass, interfaceMeta, info, args);
+    result = [klass alloc];
+
+    V8VectorArgs vectorArgs(args);
+    result = Interop::CallInitializer(context, initializer, result, klass, vectorArgs);
+  }
+
+  if (result == nil) {
+    result = [[klass alloc] init];
+  }
+
+  auto cache = Caches::Get(isolate);
+  auto it = cache->Instances.find(result);
+  if (it != cache->Instances.end()) {
+    Local<Value> obj = it->second->Get(isolate);
+    info.GetReturnValue().Set(obj);
+  } else {
+    ObjCDataWrapper* wrapper = new ObjCDataWrapper(result);
+    Local<Object> thiz = info.This();
+    Local<Context> context = cache->GetContext();
+    tns::SetValue(isolate, thiz, wrapper);
+    std::shared_ptr<Persistent<Value>> poThiz = ObjectManager::Register(context, thiz);
+    cache->Instances.emplace(result, poThiz);
+    // [result retain];
+  }
+}
+
+const MethodMeta* ArgConverter::FindInitializer(Local<Context> context, Class klass,
+                                                const InterfaceMeta* interfaceMeta,
+                                                const FunctionCallbackInfo<Value>& info,
+                                                std::vector<Local<Value>>& args) {
+  Isolate* isolate = context->GetIsolate();
+  std::vector<const MethodMeta*> candidates;
+  args = tns::ArgsToVector(info);
+  std::vector<Local<Value>> initializerArgs;
+  std::string constructorTokens;
+  if (info.Length() == 1 && info[0]->IsObject() && tns::GetValue(isolate, info[0]) == nullptr) {
+    initializerArgs = GetInitializerArgs(info[0].As<Object>(), constructorTokens);
+  }
+
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+  bool found = false;
+  do {
+    std::vector<const MethodMeta*> initializers =
+        ArgConverter::GetInitializers(cache.get(), klass, interfaceMeta);
+    for (const MethodMeta* candidate : initializers) {
+      if (constructorTokens != "") {
+        const char* expectedTokens = candidate->constructorTokens();
+        if (strcmp(expectedTokens, constructorTokens.c_str()) == 0) {
+          candidates.clear();
+          candidates.push_back(candidate);
+          args = initializerArgs;
+          found = true;
+          break;
+        }
+      }
+
+      if (ArgConverter::CanInvoke(context, candidate, info)) {
+        candidates.push_back(candidate);
+      }
+    }
+
+    if (found) {
+      break;
+    }
+
+    interfaceMeta = interfaceMeta->baseMeta();
+  } while (interfaceMeta);
+
+  if (candidates.size() == 0) {
+    throw NativeScriptException("No initializer found that matches constructor invocation.");
+  } else if (candidates.size() > 1) {
+    if (info.Length() == 0) {
+      auto it = std::find_if(candidates.begin(), candidates.end(), [](const MethodMeta* c) -> bool {
+        return strcmp(c->name(), "init") == 0;
+      });
+      if (it != candidates.end()) {
+        return (*it);
+      }
+    }
+
+    std::stringstream ss;
+    ss << "More than one initializer found that matches constructor invocation:";
+    for (int i = 0; i < candidates.size(); i++) {
+      ss << " ";
+      ss << candidates[i]->selectorAsString();
+    }
+    std::string errorMessage = ss.str();
+    throw NativeScriptException(errorMessage);
+  }
+
+  return candidates[0];
+}
+
+bool ArgConverter::CanInvoke(Local<Context> context, const MethodMeta* candidate,
+                             const FunctionCallbackInfo<Value>& info) {
+  if (candidate->encodings()->count - 1 != info.Length()) {
+    return false;
+  }
+
+  if (info.Length() == 0) {
+    return true;
+  }
+
+  const TypeEncoding* typeEncoding = candidate->encodings()->first();
+  for (int i = 0; i < info.Length(); i++) {
+    typeEncoding = typeEncoding->next();
+    Local<Value> arg = info[i];
+
+    if (!CanInvoke(context, typeEncoding, arg)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool ArgConverter::CanInvoke(Local<Context> context, const TypeEncoding* typeEncoding,
+                             Local<Value> arg) {
+  if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
+    return true;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+    const char* name = typeEncoding->details.declarationReference.name.valuePtr();
+    if (strcmp(name, "NSNumber") == 0 && tns::IsNumber(arg)) {
+      return true;
+    }
+
+    if (strcmp(name, "NSString") == 0 && tns::IsString(arg)) {
+      return true;
+    }
+
+    if (strcmp(name, "NSArray") == 0 && arg->IsArray()) {
+      return true;
+    }
+
+    if (BaseDataWrapper* wrapper = tns::GetValue(isolate, arg)) {
+      if (wrapper->Type() == WrapperType::ObjCObject) {
+        ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+        Class candidateClass = objc_getClass(name);
+        if (candidateClass != nil && [objcWrapper->Data() isKindOfClass:candidateClass]) {
+          return true;
+        }
+      }
+    }
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
+    return arg->IsObject();
+  }
+
+  if (tns::IsBool(arg)) {
+    return typeEncoding->type == BinaryTypeEncodingType::BoolEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::IdEncoding;
+  }
+
+  if (tns::IsNumber(arg)) {
+    return typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::UShortEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::ShortEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::UIntEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::IntEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::ULongEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::LongEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::ULongLongEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::LongLongEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::FloatEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::DoubleEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::UCharEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::CharEncoding;
+  }
+
+  if (tns::IsString(arg)) {
+    return typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::UnicharEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::CStringEncoding;
+  }
+
+  if (arg->IsFunction()) {
+    return typeEncoding->type == BinaryTypeEncodingType::BlockEncoding ||
+           typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding;
+  }
+
+  if (arg->IsArrayBuffer() || arg->IsArrayBufferView() || arg->IsSharedArrayBuffer()) {
+    return typeEncoding->type == BinaryTypeEncodingType::IncompleteArrayEncoding;
+  }
+
+  return false;
+}
+
+std::vector<Local<Value>> ArgConverter::GetInitializerArgs(Local<Object> obj,
+                                                           std::string& constructorTokens) {
+  std::vector<Local<Value>> args;
+  constructorTokens = "";
+  Local<Context> context;
+  bool success = obj->GetCreationContext().ToLocal(&context);
+  tns::Assert(success);
+  Isolate* isolate = context->GetIsolate();
+  Local<v8::Array> properties;
+  if (obj->GetOwnPropertyNames(context).ToLocal(&properties)) {
+    std::stringstream ss;
+    for (uint32_t i = 0; i < properties->Length(); i++) {
+      Local<Value> propertyName;
+      if (properties->Get(context, i).ToLocal(&propertyName)) {
+        std::string name = tns::ToString(isolate, propertyName);
+        ss << name << ":";
+        Local<Value> propertyValue;
+        bool ok = obj->Get(context, propertyName).ToLocal(&propertyValue);
+        tns::Assert(ok, isolate);
+        args.push_back(propertyValue);
+      }
+    }
+    constructorTokens = ss.str();
+  }
+
+  return args;
+}
+
+Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapper* wrapper,
+                                           Local<Object> receiver, bool skipGCRegistration,
+                                           const std::vector<std::string>& additionalProtocols) {
+  Isolate* isolate = context->GetIsolate();
+
+  if (wrapper == nullptr) {
+    return Null(isolate);
+  }
+
+  if (wrapper->Type() == WrapperType::Struct) {
+    if (receiver.IsEmpty()) {
+      std::shared_ptr<Persistent<Value>> poStruct = CreateEmptyStruct(context);
+      receiver = poStruct->Get(isolate).As<Object>();
+    }
+
+    StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+    StructInfo structInfo = structWrapper->StructInfo();
+    auto cache = Caches::Get(isolate);
+    Local<v8::Function> structCtorFunc = cache->StructCtorInitializer(context, structInfo);
+    Local<Value> proto;
+    bool success =
+        structCtorFunc->Get(context, tns::ToV8String(isolate, "prototype")).ToLocal(&proto);
+
+    if (success && !proto.IsEmpty()) {
+      success = receiver->SetPrototype(context, proto).FromMaybe(false);
+      tns::Assert(success, isolate);
+    }
+
+    tns::SetValue(isolate, receiver, structWrapper);
 
     return receiver;
+  }
+
+  if (wrapper->Type() == WrapperType::ObjCAllocObject) {
+    ObjCAllocDataWrapper* allocDataWrapper = static_cast<ObjCAllocDataWrapper*>(wrapper);
+    Class klass = allocDataWrapper->Klass();
+
+    std::shared_ptr<Persistent<Value>> poValue = CreateEmptyObject(context, false);
+    receiver = poValue->Get(isolate).As<Object>();
+
+    const Meta* meta = FindMeta(klass);
+    if (meta != nullptr) {
+      auto cache = Caches::Get(isolate);
+      KnownUnknownClassPair pair(objc_getClass(meta->name()));
+      std::vector<std::string> emptyProtocols;
+      cache->ObjectCtorInitializer(context, static_cast<const BaseClassMeta*>(meta), pair,
+                                   emptyProtocols);
+      auto it = cache->Prototypes.find(meta);
+      if (it != cache->Prototypes.end()) {
+        Local<Value> prototype = it->second->Get(isolate);
+        bool success;
+        if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
+          tns::Assert(false, isolate);
+        }
+      }
+    }
+
+    tns::SetValue(isolate, receiver, wrapper);
+
+    return receiver;
+  }
+
+  id target = nil;
+  const TypeEncoding* typeEncoding = nullptr;
+  if (wrapper->Type() == WrapperType::ObjCObject) {
+    ObjCDataWrapper* dataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+    target = dataWrapper->Data();
+    typeEncoding = dataWrapper->TypeEncoding();
+  }
+
+  if (target == nil) {
+    return Null(isolate);
+  }
+
+  auto cache = Caches::Get(isolate);
+  if (receiver.IsEmpty()) {
+    auto it = cache->Instances.find(target);
+    if (it != cache->Instances.end()) {
+      receiver = it->second->Get(isolate).As<Object>();
+    } else {
+      std::shared_ptr<Persistent<Value>> poValue = CreateEmptyObject(context, skipGCRegistration);
+      receiver = poValue->Get(isolate).As<Object>();
+      tns::SetValue(isolate, receiver, wrapper);
+      cache->Instances.emplace(target, poValue);
+      [target retain];
+    }
+  } else {
+    tns::SetValue(isolate, receiver, wrapper);
+  }
+
+  Class klass = [target class];
+  const Meta* meta = FindMeta(klass, typeEncoding);
+  if (meta != nullptr) {
+    std::string className = object_getClassName(target);
+    auto it = cache->ClassPrototypes.find(className);
+    if (it != cache->ClassPrototypes.end()) {
+      // for debugging rlv cell handling:
+      // NSString* message = [NSString stringWithFormat:@"ArgConverter::CreateJsWrapper FindMeta:
+      // class {%@}", NSStringFromClass(klass)]; Log(@"%@", message);
+      Local<Value> prototype = it->second->Get(isolate);
+      bool success;
+      if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
+        tns::Assert(false, isolate);
+      }
+    } else {
+      Class knownClass = objc_getClass(meta->name());
+      KnownUnknownClassPair pair(knownClass, klass);
+      Local<FunctionTemplate> ctorFuncTemplate = cache->ObjectCtorInitializer(
+          context, static_cast<const BaseClassMeta*>(meta), pair, additionalProtocols);
+      Local<v8::Function> ctorFunc;
+      bool success = ctorFuncTemplate->GetFunction(context).ToLocal(&ctorFunc);
+      tns::Assert(success, isolate);
+
+      Local<Value> prototypeValue;
+      success =
+          ctorFunc->Get(context, tns::ToV8String(isolate, "prototype")).ToLocal(&prototypeValue);
+      tns::Assert(success, isolate);
+      Local<Object> prototype = prototypeValue.As<Object>();
+
+      if (!receiver->SetPrototype(context, prototype).To(&success) || !success) {
+        tns::Assert(false, isolate);
+      }
+    }
+  }
+
+  Class metaClass = object_getClass(target);
+  if (class_isMetaClass(metaClass)) {
+    if (tns::GetValue(isolate, receiver) == nullptr) {
+      ObjCClassWrapper* wrapper = new ObjCClassWrapper(klass);
+      tns::SetValue(isolate, receiver, wrapper);
+    }
+  }
+
+  return receiver;
 }
 
 const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding) {
-    if (typeEncoding != nullptr && typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-        const char* name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
-        const Meta* result = GetMeta(name);
-        if (result != nullptr && result->type() == MetaType::Interface) {
-            return result;
-        }
+  if (typeEncoding != nullptr &&
+      typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+    const char* name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+    const Meta* result = GetMeta(name);
+    if (result != nullptr && result->type() == MetaType::Interface) {
+      return result;
+    }
+  }
+
+  std::string origClassName = class_getName(klass);
+  const Meta* meta = Caches::Metadata->Get(origClassName);
+  if (meta != nullptr) {
+    return meta;
+  }
+
+  std::string className = origClassName;
+
+  while (true) {
+    const Meta* result = GetMeta(className);
+    if (result != nullptr && result->type() == MetaType::Interface) {
+      Caches::Metadata->Insert(origClassName, result);
+      return result;
     }
 
-    std::string origClassName = class_getName(klass);
-    const Meta* meta = Caches::Metadata->Get(origClassName);
-    if (meta != nullptr) {
-        return meta;
+    klass = class_getSuperclass(klass);
+    if (klass == nullptr) {
+      break;
     }
 
-    std::string className = origClassName;
+    className = class_getName(klass);
+  }
 
-    while (true) {
-        const Meta* result = GetMeta(className);
-        if (result != nullptr && result->type() == MetaType::Interface) {
-            Caches::Metadata->Insert(origClassName, result);
-            return result;
-        }
-
-        klass = class_getSuperclass(klass);
-        if (klass == nullptr) {
-            break;
-        }
-
-        className = class_getName(klass);
-    }
-
-    return nullptr;
+  return nullptr;
 }
 
 const Meta* ArgConverter::GetMeta(std::string name) {
-    bool found;
-    const Meta* meta = Caches::Metadata->Get(name, found);
-    if (meta != nullptr || found) {
-        return meta;
-    }
+  bool found;
+  const Meta* meta = Caches::Metadata->Get(name, found);
+  if (meta != nullptr || found) {
+    return meta;
+  }
 
-    const GlobalTable<GlobalTableType::ByJsName>* globalTable = MetaFile::instance()->globalTableJs();
-    const Meta* result = globalTable->findMeta(name.c_str(), false /** onlyIfAvailable **/);
+  const GlobalTable<GlobalTableType::ByJsName>* globalTable = MetaFile::instance()->globalTableJs();
+  const Meta* result = globalTable->findMeta(name.c_str(), false /** onlyIfAvailable **/);
+
+  if (result == nullptr) {
+    const GlobalTable<GlobalTableType::ByNativeName>* globalTableInterfaceNames =
+        MetaFile::instance()->globalTableNativeInterfaces();
+    result = globalTableInterfaceNames->findMeta(name.c_str(), false /** onlyIfAvailable **/);
 
     if (result == nullptr) {
-        const GlobalTable<GlobalTableType::ByNativeName>* globalTableInterfaceNames = MetaFile::instance()->globalTableNativeInterfaces();
-        result = globalTableInterfaceNames->findMeta(name.c_str(), false /** onlyIfAvailable **/);
-
-        if (result == nullptr) {
-            const GlobalTable<GlobalTableType::ByNativeName>* globalTableProtocolNames = MetaFile::instance()->globalTableNativeProtocols();
-            result = globalTableProtocolNames->findMeta(name.c_str(), false /** onlyIfAvailable **/);
-        }
+      const GlobalTable<GlobalTableType::ByNativeName>* globalTableProtocolNames =
+          MetaFile::instance()->globalTableNativeProtocols();
+      result = globalTableProtocolNames->findMeta(name.c_str(), false /** onlyIfAvailable **/);
     }
+  }
 
-    Caches::Metadata->Insert(name, result);
+  Caches::Metadata->Insert(name, result);
 
-    return result;
+  return result;
 }
 
 const ProtocolMeta* ArgConverter::FindProtocolMeta(Protocol* protocol) {
-    std::string protocolName = protocol_getName(protocol);
-    const Meta* meta = ArgConverter::GetMeta(protocolName);
-    if (meta != nullptr && meta->type() != MetaType::ProtocolType) {
-        std::string newProtocolName = protocolName + "Protocol";
+  std::string protocolName = protocol_getName(protocol);
+  const Meta* meta = ArgConverter::GetMeta(protocolName);
+  if (meta != nullptr && meta->type() != MetaType::ProtocolType) {
+    std::string newProtocolName = protocolName + "Protocol";
 
-        size_t protocolIndex = 2;
-        while (objc_getProtocol(newProtocolName.c_str())) {
-            newProtocolName = protocolName + "Protocol" + std::to_string(protocolIndex++);
-        }
-
-        meta = ArgConverter::GetMeta(newProtocolName);
+    size_t protocolIndex = 2;
+    while (objc_getProtocol(newProtocolName.c_str())) {
+      newProtocolName = protocolName + "Protocol" + std::to_string(protocolIndex++);
     }
 
-    if (meta == nullptr) {
-        return nullptr;
-    }
+    meta = ArgConverter::GetMeta(newProtocolName);
+  }
 
-    tns::Assert(meta->type() == MetaType::ProtocolType);
-    const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(meta);
-    return protocolMeta;
+  if (meta == nullptr) {
+    return nullptr;
+  }
+
+  tns::Assert(meta->type() == MetaType::ProtocolType);
+  const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(meta);
+  return protocolMeta;
 }
 
-std::shared_ptr<Persistent<Value>> ArgConverter::CreateEmptyObject(Local<Context> context, bool skipGCRegistration) {
-    Isolate* isolate = context->GetIsolate();
-    Persistent<v8::Function>* ctorFunc = Caches::Get(isolate)->EmptyObjCtorFunc.get();
-    tns::Assert(ctorFunc != nullptr, isolate);
-    return ArgConverter::CreateEmptyInstance(context, ctorFunc, skipGCRegistration);
+std::shared_ptr<Persistent<Value>> ArgConverter::CreateEmptyObject(Local<Context> context,
+                                                                   bool skipGCRegistration) {
+  Isolate* isolate = context->GetIsolate();
+  Persistent<v8::Function>* ctorFunc = Caches::Get(isolate)->EmptyObjCtorFunc.get();
+  tns::Assert(ctorFunc != nullptr, isolate);
+  return ArgConverter::CreateEmptyInstance(context, ctorFunc, skipGCRegistration);
 }
 
 std::shared_ptr<Persistent<Value>> ArgConverter::CreateEmptyStruct(Local<Context> context) {
-    Isolate* isolate = context->GetIsolate();
-    Persistent<v8::Function>* ctorFunc = Caches::Get(isolate)->EmptyStructCtorFunc.get();
-    tns::Assert(ctorFunc != nullptr, isolate);
-    return ArgConverter::CreateEmptyInstance(context, ctorFunc);
+  Isolate* isolate = context->GetIsolate();
+  Persistent<v8::Function>* ctorFunc = Caches::Get(isolate)->EmptyStructCtorFunc.get();
+  tns::Assert(ctorFunc != nullptr, isolate);
+  return ArgConverter::CreateEmptyInstance(context, ctorFunc);
 }
 
-std::shared_ptr<Persistent<Value>> ArgConverter::CreateEmptyInstance(Local<Context> context, Persistent<v8::Function>* ctorFunc, bool skipGCRegistration) {
-    Isolate* isolate = context->GetIsolate();
-    Local<v8::Function> emptyCtorFunc = ctorFunc->Get(isolate);
-    Local<Value> value;
-    if (!emptyCtorFunc->CallAsConstructor(context, 0, nullptr).ToLocal(&value) || value.IsEmpty() || !value->IsObject()) {
-        tns::Assert(false, isolate);
-    }
-    Local<Object> result = value.As<Object>();
+std::shared_ptr<Persistent<Value>> ArgConverter::CreateEmptyInstance(
+    Local<Context> context, Persistent<v8::Function>* ctorFunc, bool skipGCRegistration) {
+  Isolate* isolate = context->GetIsolate();
+  Local<v8::Function> emptyCtorFunc = ctorFunc->Get(isolate);
+  Local<Value> value;
+  if (!emptyCtorFunc->CallAsConstructor(context, 0, nullptr).ToLocal(&value) || value.IsEmpty() ||
+      !value->IsObject()) {
+    tns::Assert(false, isolate);
+  }
+  Local<Object> result = value.As<Object>();
 
-    std::shared_ptr<Persistent<Value>> poValue;
-    if (!skipGCRegistration) {
-        poValue = ObjectManager::Register(context, result);
-    } else {
-        poValue = std::make_shared<Persistent<Value>>(isolate, result);
-    }
+  std::shared_ptr<Persistent<Value>> poValue;
+  if (!skipGCRegistration) {
+    poValue = ObjectManager::Register(context, result);
+  } else {
+    poValue = std::make_shared<Persistent<Value>>(isolate, result);
+  }
 
-    return poValue;
+  return poValue;
 }
 
-Local<v8::Function> ArgConverter::CreateEmptyInstanceFunction(Local<Context> context, GenericNamedPropertyGetterCallback propertyGetter, GenericNamedPropertySetterCallback propertySetter) {
-    Isolate* isolate = context->GetIsolate();
-    Local<FunctionTemplate> emptyInstanceCtorFuncTemplate = FunctionTemplate::New(isolate, nullptr);
-    Local<ObjectTemplate> instanceTemplate = emptyInstanceCtorFuncTemplate->InstanceTemplate();
-    instanceTemplate->SetInternalFieldCount(2);
+Local<v8::Function> ArgConverter::CreateEmptyInstanceFunction(
+    Local<Context> context, GenericNamedPropertyGetterCallback propertyGetter,
+    GenericNamedPropertySetterCallback propertySetter) {
+  Isolate* isolate = context->GetIsolate();
+  Local<FunctionTemplate> emptyInstanceCtorFuncTemplate = FunctionTemplate::New(isolate, nullptr);
+  Local<ObjectTemplate> instanceTemplate = emptyInstanceCtorFuncTemplate->InstanceTemplate();
+  instanceTemplate->SetInternalFieldCount(2);
 
-    if (propertyGetter != nullptr || propertySetter != nullptr) {
-        NamedPropertyHandlerConfiguration config(propertyGetter, propertySetter);
-        instanceTemplate->SetHandler(config);
-    }
+  if (propertyGetter != nullptr || propertySetter != nullptr) {
+    NamedPropertyHandlerConfiguration config(propertyGetter, propertySetter);
+    instanceTemplate->SetHandler(config);
+  }
 
-    instanceTemplate->SetIndexedPropertyHandler(IndexedPropertyGetterCallback, IndexedPropertySetterCallback);
+  instanceTemplate->SetIndexedPropertyHandler(IndexedPropertyGetterCallback,
+                                              IndexedPropertySetterCallback);
 
-    Local<v8::Function> emptyInstanceCtorFunc;
-    if (!emptyInstanceCtorFuncTemplate->GetFunction(context).ToLocal(&emptyInstanceCtorFunc)) {
-        tns::Assert(false, isolate);
-    }
-    return emptyInstanceCtorFunc;
+  Local<v8::Function> emptyInstanceCtorFunc;
+  if (!emptyInstanceCtorFuncTemplate->GetFunction(context).ToLocal(&emptyInstanceCtorFunc)) {
+    tns::Assert(false, isolate);
+  }
+  return emptyInstanceCtorFunc;
 }
 
-void ArgConverter::IndexedPropertyGetterCallback(uint32_t index, const PropertyCallbackInfo<Value>& args) {
-    Local<Object> thiz = args.This();
-    Isolate* isolate = args.GetIsolate();
-    BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
-    if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
-        return;
-    }
+void ArgConverter::IndexedPropertyGetterCallback(uint32_t index,
+                                                 const PropertyCallbackInfo<Value>& args) {
+  Local<Object> thiz = args.This();
+  Isolate* isolate = args.GetIsolate();
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
+  if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
+    return;
+  }
 
-    ObjCDataWrapper* objcDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-    id target = objcDataWrapper->Data();
-    if (![target isKindOfClass:[NSArray class]]) {
-        return;
-    }
+  ObjCDataWrapper* objcDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+  id target = objcDataWrapper->Data();
+  if (![target isKindOfClass:[NSArray class]]) {
+    return;
+  }
 
-    NSArray* array = (NSArray*)target;
-    if (index >= [array count]) {
-        return;
-    }
+  NSArray* array = (NSArray*)target;
+  if (index >= [array count]) {
+    return;
+  }
 
-    id obj = [array objectAtIndex:index];
+  id obj = [array objectAtIndex:index];
 
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-    auto it = cache->Instances.find(obj);
-    if (it != cache->Instances.end()) {
-        args.GetReturnValue().Set(it->second->Get(isolate));
-        return;
-    }
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+  auto it = cache->Instances.find(obj);
+  if (it != cache->Instances.end()) {
+    args.GetReturnValue().Set(it->second->Get(isolate));
+    return;
+  }
 
-    if (obj == nil || obj == [NSNull null]) {
-        args.GetReturnValue().SetNull();
-        return;
-    }
+  if (obj == nil || obj == [NSNull null]) {
+    args.GetReturnValue().SetNull();
+    return;
+  }
 
-    if ([obj isKindOfClass:[@YES class]]) {
-        args.GetReturnValue().Set([obj boolValue]);
-        return;
-    }
+  if ([obj isKindOfClass:[@YES class]]) {
+    args.GetReturnValue().Set([obj boolValue]);
+    return;
+  }
 
-    if ([obj isKindOfClass:[NSDate class]]) {
-        Local<Context> context = isolate->GetCurrentContext();
-        double time = [obj timeIntervalSince1970] * 1000.0;
-        Local<Value> date;
-        if (Date::New(context, time).ToLocal(&date)) {
-            args.GetReturnValue().Set(date);
-            return;
-        }
-
-        std::ostringstream errorStream;
-        errorStream << "Unable to convert " << [obj description] << " to a Date object";
-        std::string errorMessage = errorStream.str();
-        Local<Value> error = Exception::Error(tns::ToV8String(isolate, errorMessage));
-        isolate->ThrowException(error);
-        return;
-    }
-
-    if ([obj isKindOfClass:[NSString class]]) {
-        const char* str = [obj UTF8String];
-        args.GetReturnValue().Set(tns::ToV8String(isolate, str));
-        return;
-    }
-
-    if ([obj isKindOfClass:[NSNumber class]] && ![obj isKindOfClass:[NSDecimalNumber class]]) {
-        double value = [obj doubleValue];
-        args.GetReturnValue().Set(value);
-        return;
-    }
-
+  if ([obj isKindOfClass:[NSDate class]]) {
     Local<Context> context = isolate->GetCurrentContext();
-    auto newWrapper = new ObjCDataWrapper(obj);
-    Local<Value> result = ArgConverter::ConvertArgument(context, newWrapper);
-    tns::DeleteWrapperIfUnused(isolate, result, newWrapper);
-    args.GetReturnValue().Set(result);
+    double time = [obj timeIntervalSince1970] * 1000.0;
+    Local<Value> date;
+    if (Date::New(context, time).ToLocal(&date)) {
+      args.GetReturnValue().Set(date);
+      return;
+    }
+
+    std::ostringstream errorStream;
+    errorStream << "Unable to convert " << [obj description] << " to a Date object";
+    std::string errorMessage = errorStream.str();
+    Local<Value> error = Exception::Error(tns::ToV8String(isolate, errorMessage));
+    isolate->ThrowException(error);
+    return;
+  }
+
+  if ([obj isKindOfClass:[NSString class]]) {
+    const char* str = [obj UTF8String];
+    args.GetReturnValue().Set(tns::ToV8String(isolate, str));
+    return;
+  }
+
+  if ([obj isKindOfClass:[NSNumber class]] && ![obj isKindOfClass:[NSDecimalNumber class]]) {
+    double value = [obj doubleValue];
+    args.GetReturnValue().Set(value);
+    return;
+  }
+
+  Local<Context> context = isolate->GetCurrentContext();
+  auto newWrapper = new ObjCDataWrapper(obj);
+  Local<Value> result = ArgConverter::ConvertArgument(context, newWrapper);
+  tns::DeleteWrapperIfUnused(isolate, result, newWrapper);
+  args.GetReturnValue().Set(result);
 }
 
-void ArgConverter::IndexedPropertySetterCallback(uint32_t index, Local<Value> value, const PropertyCallbackInfo<Value>& args) {
-    Local<Object> thiz = args.This();
-    Isolate* isolate = args.GetIsolate();
-    BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
-    if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
-        return;
-    }
+void ArgConverter::IndexedPropertySetterCallback(uint32_t index, Local<Value> value,
+                                                 const PropertyCallbackInfo<Value>& args) {
+  Local<Object> thiz = args.This();
+  Isolate* isolate = args.GetIsolate();
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
+  if (wrapper == nullptr || wrapper->Type() != WrapperType::ObjCObject) {
+    return;
+  }
 
-    ObjCDataWrapper* objcDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-    id target = objcDataWrapper->Data();
-    if (![target isKindOfClass:[NSMutableArray class]]) {
-        return;
-    }
+  ObjCDataWrapper* objcDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+  id target = objcDataWrapper->Data();
+  if (![target isKindOfClass:[NSMutableArray class]]) {
+    return;
+  }
 
-    NSMutableArray* array = (NSMutableArray*)target;
-    if (index >= [array count]) {
-        return;
-    }
+  NSMutableArray* array = (NSMutableArray*)target;
+  if (index >= [array count]) {
+    return;
+  }
 
-    BaseDataWrapper* itemWrapper = tns::GetValue(isolate, value);
-    if (itemWrapper == nullptr || itemWrapper->Type() != WrapperType::ObjCObject) {
-        return;
-    }
+  BaseDataWrapper* itemWrapper = tns::GetValue(isolate, value);
+  if (itemWrapper == nullptr || itemWrapper->Type() != WrapperType::ObjCObject) {
+    return;
+  }
 
-    ObjCDataWrapper* objcItemDataWrapper = static_cast<ObjCDataWrapper*>(itemWrapper);
-    id item = objcItemDataWrapper->Data();
-    [target replaceObjectAtIndex:index withObject:item];
+  ObjCDataWrapper* objcItemDataWrapper = static_cast<ObjCDataWrapper*>(itemWrapper);
+  id item = objcItemDataWrapper->Data();
+  [target replaceObjectAtIndex:index withObject:item];
 }
 
-void ArgConverter::FindMethodOverloads(Class klass, std::string methodName, MemberType type, std::vector<const MethodMeta*>& overloads) {
-    const Meta* meta = ArgConverter::FindMeta(klass);
-    if (klass == nullptr || meta == nullptr || meta->type() != MetaType::Interface) {
-        return;
-    }
+void ArgConverter::FindMethodOverloads(Class klass, std::string methodName, MemberType type,
+                                       std::vector<const MethodMeta*>& overloads) {
+  const Meta* meta = ArgConverter::FindMeta(klass);
+  if (klass == nullptr || meta == nullptr || meta->type() != MetaType::Interface) {
+    return;
+  }
 
-    const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(meta);
-    MembersCollection members = interfaceMeta->members(methodName.c_str(), methodName.length(), type, true, true, ProtocolMetas());
-    for (auto it = members.begin(); it != members.end(); it++) {
-        const MethodMeta* methodMeta = static_cast<const MethodMeta*>(*it);
-        overloads.push_back(methodMeta);
-    }
+  const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(meta);
+  MembersCollection members = interfaceMeta->members(methodName.c_str(), methodName.length(), type,
+                                                     true, true, ProtocolMetas());
+  for (auto it = members.begin(); it != members.end(); it++) {
+    const MethodMeta* methodMeta = static_cast<const MethodMeta*>(*it);
+    overloads.push_back(methodMeta);
+  }
 
-    if (interfaceMeta->baseName() != nullptr) {
-        Class baseClass = objc_getClass(interfaceMeta->baseName());
-        ArgConverter::FindMethodOverloads(baseClass, methodName, type, overloads);
-    }
+  if (interfaceMeta->baseName() != nullptr) {
+    Class baseClass = objc_getClass(interfaceMeta->baseName());
+    ArgConverter::FindMethodOverloads(baseClass, methodName, type, overloads);
+  }
 }
 
 bool ArgConverter::IsErrorOutParameter(const TypeEncoding* typeEncoding) {
-    if (typeEncoding->type != BinaryTypeEncodingType::PointerEncoding) {
-        return false;
-    }
+  if (typeEncoding->type != BinaryTypeEncodingType::PointerEncoding) {
+    return false;
+  }
 
-    const TypeEncoding* innerTypeEncoding = typeEncoding->details.pointer.getInnerType();
-    if (innerTypeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference) {
-        return false;
-    }
+  const TypeEncoding* innerTypeEncoding = typeEncoding->details.pointer.getInnerType();
+  if (innerTypeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference) {
+    return false;
+  }
 
-    const char* name = innerTypeEncoding->details.declarationReference.name.valuePtr();
-    if (name == nullptr) {
-        return false;
-    }
+  const char* name = innerTypeEncoding->details.declarationReference.name.valuePtr();
+  if (name == nullptr) {
+    return false;
+  }
 
-    return strcmp(name, "NSError") == 0;
+  return strcmp(name, "NSError") == 0;
 }
 
-std::vector<const MethodMeta*> ArgConverter::GetInitializers(Caches* cache, Class klass, const InterfaceMeta* interfaceMeta) {
-    auto it = cache->Initializers.find(interfaceMeta);
-    if (it != cache->Initializers.end()) {
-        return it->second;
-    }
+std::vector<const MethodMeta*> ArgConverter::GetInitializers(Caches* cache, Class klass,
+                                                             const InterfaceMeta* interfaceMeta) {
+  auto it = cache->Initializers.find(interfaceMeta);
+  if (it != cache->Initializers.end()) {
+    return it->second;
+  }
 
-    KnownUnknownClassPair klasses(klass);
-    std::vector<const MethodMeta*> initializers = interfaceMeta->initializersWithProtocols(klasses, ProtocolMetas());
+  KnownUnknownClassPair klasses(klass);
+  std::vector<const MethodMeta*> initializers =
+      interfaceMeta->initializersWithProtocols(klasses, ProtocolMetas());
 
-    cache->Initializers.emplace(interfaceMeta, initializers);
+  cache->Initializers.emplace(interfaceMeta, initializers);
 
-    return initializers;
+  return initializers;
 }
 
-}
+}  // namespace tns

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -21,7 +21,7 @@ namespace {
 const int BUFFER_SIZE = 1024 * 1024;
 char* Buffer = new char[BUFFER_SIZE];
 uint8_t* BinBuffer = new uint8_t[BUFFER_SIZE];
-}
+}  // namespace
 
 std::u16string tns::ToUtf16String(Isolate* isolate, const Local<Value>& value) {
   std::string valueStr = tns::ToString(isolate, value);
@@ -310,25 +310,39 @@ bool tns::IsArrayOrArrayLike(Isolate* isolate, const Local<Value>& value) {
 void* tns::TryGetBufferFromArrayBuffer(const v8::Local<v8::Value>& value, bool& isArrayBuffer) {
   isArrayBuffer = false;
 
-  if (value.IsEmpty() || (!value->IsArrayBuffer() && !value->IsArrayBufferView())) {
+  if (value.IsEmpty() ||
+      (!value->IsArrayBuffer() && !value->IsArrayBufferView() && !value->IsSharedArrayBuffer())) {
     return nullptr;
   }
 
-  Local<ArrayBuffer> buffer;
+  std::shared_ptr<BackingStore> backingStore;
+  size_t byteOffset = 0;
   if (value->IsArrayBufferView()) {
     isArrayBuffer = true;
-    buffer = value.As<ArrayBufferView>()->Buffer();
+    auto view = value.As<ArrayBufferView>();
+    byteOffset = view->ByteOffset();
+    auto buffer = view->Buffer();
+    if (!buffer.IsEmpty()) {
+      backingStore = buffer->GetBackingStore();
+    }
   } else if (value->IsArrayBuffer()) {
     isArrayBuffer = true;
-    buffer = value.As<ArrayBuffer>();
+    backingStore = value.As<ArrayBuffer>()->GetBackingStore();
+  } else if (value->IsSharedArrayBuffer()) {
+    isArrayBuffer = true;
+    backingStore = value.As<SharedArrayBuffer>()->GetBackingStore();
   }
 
-  if (buffer.IsEmpty()) {
+  if (!backingStore) {
     return nullptr;
   }
 
-  void* data = buffer->GetBackingStore()->Data();
-  return data;
+  uint8_t* data = static_cast<uint8_t*>(backingStore->Data());
+  if (data == nullptr) {
+    return nullptr;
+  }
+
+  return data + byteOffset;
 }
 
 struct LockAndCV {
@@ -337,27 +351,27 @@ struct LockAndCV {
 };
 
 void tns::ExecuteOnRunLoop(CFRunLoopRef queue, void (^func)(void), bool async) {
-    if(!async) {
-        bool __block finished = false;
-        auto v = new LockAndCV;
-        std::unique_lock<std::mutex> lock(v->m);
-        CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, ^(void) {
-            func();
-            {
-                std::unique_lock lk(v->m);
-                finished = true;
-            }
-            v->cv.notify_all();
-        });
-        CFRunLoopWakeUp(queue);
-        while(!finished) {
-            v->cv.wait(lock);
-        }
-        delete v;
-    } else {
-        CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, func);
-        CFRunLoopWakeUp(queue);
+  if (!async) {
+    bool __block finished = false;
+    auto v = new LockAndCV;
+    std::unique_lock<std::mutex> lock(v->m);
+    CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, ^(void) {
+      func();
+      {
+        std::unique_lock lk(v->m);
+        finished = true;
+      }
+      v->cv.notify_all();
+    });
+    CFRunLoopWakeUp(queue);
+    while (!finished) {
+      v->cv.wait(lock);
     }
+    delete v;
+  } else {
+    CFRunLoopPerformBlock(queue, kCFRunLoopCommonModes, func);
+    CFRunLoopWakeUp(queue);
+  }
 }
 
 void tns::ExecuteOnDispatchQueue(dispatch_queue_t queue, std::function<void()> func, bool async) {
@@ -532,7 +546,9 @@ void tns::LogBacktrace(int skip) {
         demangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
       }
       snprintf(buf, sizeof(buf), "%-3d %*p %s + %zd\n", i, int(2 + sizeof(void*) * 2), callstack[i],
-               status == 0 ? demangled : info.dli_sname == 0 ? symbols[i] : info.dli_sname,
+               status == 0           ? demangled
+               : info.dli_sname == 0 ? symbols[i]
+                                     : info.dli_sname,
                (char*)callstack[i] - (char*)info.dli_saddr);
       free(demangled);
     } else {
@@ -938,4 +954,4 @@ void SetConstructorFunction(Isolate* isolate, Local<Template> that, Local<v8::St
   if (flag == SetConstructorFunctionFlag::SET_CLASS_NAME) tmpl->SetClassName(name);
   that->Set(name, tmpl);
 }
-};
+};  // namespace tns

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1,24 +1,24 @@
+#include "Interop.h"
 #include <Foundation/Foundation.h>
 #include <sstream>
-#include "Runtime.h"
-#include "Interop.h"
-#include "ObjectManager.h"
-#include "Helpers.h"
 #include "ArgConverter.h"
-#include "NativeScriptException.h"
-#include "DictionaryAdapter.h"
-#include "SymbolLoader.h"
 #include "ArrayAdapter.h"
-#include "NSDataAdapter.h"
-#include "Constants.h"
 #include "Caches.h"
-#include "Reference.h"
-#include "Pointer.h"
+#include "Constants.h"
+#include "DictionaryAdapter.h"
 #include "ExtVector.h"
+#include "Helpers.h"
+#include "NSDataAdapter.h"
+#include "NativeScriptException.h"
+#include "ObjectManager.h"
+#include "OneByteStringResource.h"
+#include "Pointer.h"
+#include "Reference.h"
+#include "Runtime.h"
 #include "RuntimeConfig.h"
 #include "SymbolIterator.h"
+#include "SymbolLoader.h"
 #include "UnmanagedType.h"
-#include "OneByteStringResource.h"
 #include "robin_hood.h"
 
 using namespace v8;
@@ -26,1668 +26,1759 @@ using namespace v8;
 namespace tns {
 
 static constexpr uint64_t kUint64AllBitsSet = static_cast<uint64_t>(int64_t{-1});
-static constexpr int64_t kMinSafeInteger = static_cast<int64_t>(kUint64AllBitsSet << 53) + 1; // -9007199254740991 (-(2^53-1))
-static constexpr int64_t kMaxSafeInteger = -kMinSafeInteger; // 9007199254740991 (2^53-1)
+static constexpr int64_t kMinSafeInteger =
+    static_cast<int64_t>(kUint64AllBitsSet << 53) + 1;        // -9007199254740991 (-(2^53-1))
+static constexpr int64_t kMaxSafeInteger = -kMinSafeInteger;  // 9007199254740991 (2^53-1)
 
 Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
     .reserved = 0,
     .size = sizeof(JSBlock),
-    .copy = [](JSBlock* dst, const JSBlock* src) {
-    },
-    .dispose = [](JSBlock* block) {
-        if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
+    .copy = [](JSBlock* dst, const JSBlock* src) {},
+    .dispose =
+        [](JSBlock* block) {
+          if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
             MethodCallbackWrapper* wrapper = static_cast<MethodCallbackWrapper*>(block->userData);
             if (wrapper->isolateWrapper_.IsValid()) {
-                Isolate* isolate = wrapper->isolateWrapper_.Isolate();
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                Local<Value> callback = wrapper->callback_->Get(isolate);
-                if (!callback.IsEmpty() && callback->IsObject()) {
-                    BlockWrapper* blockWrapper = static_cast<BlockWrapper*>(tns::GetValue(isolate, callback));
-                    tns::DeleteValue(isolate, callback);
-                    wrapper->callback_->Reset();
-                    delete blockWrapper;
-                }
+              Isolate* isolate = wrapper->isolateWrapper_.Isolate();
+              v8::Locker locker(isolate);
+              Isolate::Scope isolate_scope(isolate);
+              HandleScope handle_scope(isolate);
+              Local<Value> callback = wrapper->callback_->Get(isolate);
+              if (!callback.IsEmpty() && callback->IsObject()) {
+                BlockWrapper* blockWrapper =
+                    static_cast<BlockWrapper*>(tns::GetValue(isolate, callback));
+                tns::DeleteValue(isolate, callback);
+                wrapper->callback_->Reset();
+                delete blockWrapper;
+              }
             }
             delete wrapper;
             ffi_closure_free(block->ffiClosure);
             block->~JSBlock();
-        }
-    }
-};
+          }
+        }};
 
-std::pair<IMP, ffi_closure*> Interop::CreateMethodInternal(const uint8_t initialParamIndex, const uint8_t argsCount, const TypeEncoding* typeEncoding, FFIMethodCallback callback, void* userData) {
-    void* functionPointer;
-    ffi_closure* closure = static_cast<ffi_closure*>(ffi_closure_alloc(sizeof(ffi_closure), &functionPointer));
-    ParametrizedCall* call = ParametrizedCall::Get(typeEncoding, initialParamIndex, initialParamIndex + argsCount);
-    ffi_status status = ffi_prep_closure_loc(closure, call->Cif, callback, userData, functionPointer);
-    tns::Assert(status == FFI_OK);
+std::pair<IMP, ffi_closure*> Interop::CreateMethodInternal(const uint8_t initialParamIndex,
+                                                           const uint8_t argsCount,
+                                                           const TypeEncoding* typeEncoding,
+                                                           FFIMethodCallback callback,
+                                                           void* userData) {
+  void* functionPointer;
+  ffi_closure* closure =
+      static_cast<ffi_closure*>(ffi_closure_alloc(sizeof(ffi_closure), &functionPointer));
+  ParametrizedCall* call =
+      ParametrizedCall::Get(typeEncoding, initialParamIndex, initialParamIndex + argsCount);
+  ffi_status status = ffi_prep_closure_loc(closure, call->Cif, callback, userData, functionPointer);
+  tns::Assert(status == FFI_OK);
 
-    return std::make_pair((IMP)functionPointer, closure);
-
+  return std::make_pair((IMP)functionPointer, closure);
 }
 
-IMP Interop::CreateMethod(const uint8_t initialParamIndex, const uint8_t argsCount, const TypeEncoding* typeEncoding, FFIMethodCallback callback, void* userData) {
-    std::pair<IMP, ffi_closure*> result = Interop::CreateMethodInternal(initialParamIndex, argsCount, typeEncoding, callback, userData);
-    return result.first;
+IMP Interop::CreateMethod(const uint8_t initialParamIndex, const uint8_t argsCount,
+                          const TypeEncoding* typeEncoding, FFIMethodCallback callback,
+                          void* userData) {
+  std::pair<IMP, ffi_closure*> result =
+      Interop::CreateMethodInternal(initialParamIndex, argsCount, typeEncoding, callback, userData);
+  return result.first;
 }
 
-CFTypeRef Interop::CreateBlock(const uint8_t initialParamIndex, const uint8_t argsCount, const TypeEncoding* typeEncoding, FFIMethodCallback callback, void* userData) {
-    JSBlock* blockPointer = reinterpret_cast<JSBlock*>(malloc(sizeof(JSBlock)));
+CFTypeRef Interop::CreateBlock(const uint8_t initialParamIndex, const uint8_t argsCount,
+                               const TypeEncoding* typeEncoding, FFIMethodCallback callback,
+                               void* userData) {
+  JSBlock* blockPointer = reinterpret_cast<JSBlock*>(malloc(sizeof(JSBlock)));
 
-    std::pair<IMP, ffi_closure*> result = Interop::CreateMethodInternal(initialParamIndex, argsCount, typeEncoding, callback, userData);
+  std::pair<IMP, ffi_closure*> result =
+      Interop::CreateMethodInternal(initialParamIndex, argsCount, typeEncoding, callback, userData);
 
-    *blockPointer = {
-        .isa = nullptr,
-        // this block is created with a refcount of 1
-        // this means we "own" it and need to free it
-        .flags = JSBlock::BLOCK_HAS_COPY_DISPOSE | JSBlock::BLOCK_NEEDS_FREE | (1 /* ref count */ << 1),
-        .reserved = 0,
-        .invoke = (void*)result.first,
-        .descriptor = &JSBlock::kJSBlockDescriptor,
-        .userData = userData,
-        .ffiClosure = result.second,
-    };
+  *blockPointer = {
+      .isa = nullptr,
+      // this block is created with a refcount of 1
+      // this means we "own" it and need to free it
+      .flags =
+          JSBlock::BLOCK_HAS_COPY_DISPOSE | JSBlock::BLOCK_NEEDS_FREE | (1 /* ref count */ << 1),
+      .reserved = 0,
+      .invoke = (void*)result.first,
+      .descriptor = &JSBlock::kJSBlockDescriptor,
+      .userData = userData,
+      .ffiClosure = result.second,
+  };
 
-    object_setClass((__bridge id)blockPointer, objc_getClass("__NSMallocBlock__"));
+  object_setClass((__bridge id)blockPointer, objc_getClass("__NSMallocBlock__"));
 
-    // transfer ownership back to ARC (see refcount comment above)
-    return CFBridgingRelease(blockPointer);
+  // transfer ownership back to ARC (see refcount comment above)
+  return CFBridgingRelease(blockPointer);
 }
 
 Local<Value> Interop::CallFunction(CMethodCall& methodCall) {
-    return Interop::CallFunctionInternal(methodCall);
+  return Interop::CallFunctionInternal(methodCall);
 }
 
 Local<Value> Interop::CallFunction(ObjCMethodCall& methodCall) {
-    return Interop::CallFunctionInternal(methodCall);
+  return Interop::CallFunctionInternal(methodCall);
 }
 
-id Interop::CallInitializer(Local<Context> context, const MethodMeta* methodMeta, id target, Class clazz, V8Args& args) {
-    const TypeEncoding* typeEncoding = methodMeta->encodings()->first();
-    SEL selector = methodMeta->selector();
-    void* functionPointer = (void*)objc_msgSend;
+id Interop::CallInitializer(Local<Context> context, const MethodMeta* methodMeta, id target,
+                            Class clazz, V8Args& args) {
+  const TypeEncoding* typeEncoding = methodMeta->encodings()->first();
+  SEL selector = methodMeta->selector();
+  void* functionPointer = (void*)objc_msgSend;
 
-    int initialParameterIndex = 2;
-    int argsCount = initialParameterIndex + (int)args.Length();
+  int initialParameterIndex = 2;
+  int argsCount = initialParameterIndex + (int)args.Length();
 
-    ParametrizedCall* parametrizedCall = ParametrizedCall::Get(typeEncoding, initialParameterIndex, argsCount);
-    FFICall call(parametrizedCall);
+  ParametrizedCall* parametrizedCall =
+      ParametrizedCall::Get(typeEncoding, initialParameterIndex, argsCount);
+  FFICall call(parametrizedCall);
 
-    Interop::SetValue(call.ArgumentBuffer(0), target);
-    Interop::SetValue(call.ArgumentBuffer(1), selector);
-    Interop::SetFFIParams(context, typeEncoding, &call, argsCount, initialParameterIndex, args);
+  Interop::SetValue(call.ArgumentBuffer(0), target);
+  Interop::SetValue(call.ArgumentBuffer(1), selector);
+  Interop::SetFFIParams(context, typeEncoding, &call, argsCount, initialParameterIndex, args);
 
-    ffi_call(parametrizedCall->Cif, FFI_FN(functionPointer), call.ResultBuffer(), call.ArgsArray());
+  ffi_call(parametrizedCall->Cif, FFI_FN(functionPointer), call.ResultBuffer(), call.ArgsArray());
 
-    id result = call.GetResult<id>();
+  id result = call.GetResult<id>();
 
-    return result;
+  return result;
 }
 
-void Interop::SetFFIParams(Local<Context> context, const TypeEncoding* typeEncoding, FFICall* call, const int argsCount, const int initialParameterIndex, V8Args& args) {
-    const TypeEncoding* enc = typeEncoding;
-    for (int i = initialParameterIndex; i < argsCount; i++) {
-        enc = enc->next();
-        Local<Value> arg = args[i - initialParameterIndex];
-        void* argBuffer = call->ArgumentBuffer(i);
-        Interop::WriteValue(context, enc, argBuffer, arg);
-    }
+void Interop::SetFFIParams(Local<Context> context, const TypeEncoding* typeEncoding, FFICall* call,
+                           const int argsCount, const int initialParameterIndex, V8Args& args) {
+  const TypeEncoding* enc = typeEncoding;
+  for (int i = initialParameterIndex; i < argsCount; i++) {
+    enc = enc->next();
+    Local<Value> arg = args[i - initialParameterIndex];
+    void* argBuffer = call->ArgumentBuffer(i);
+    Interop::WriteValue(context, enc, argBuffer, arg);
+  }
 }
 
-bool Interop::isRefTypeEqual(const TypeEncoding* typeEncoding, const char* clazz){
-    std::string n(&typeEncoding->details.interfaceDeclarationReference.name.value());
-    return n.compare(clazz) == 0;
+bool Interop::isRefTypeEqual(const TypeEncoding* typeEncoding, const char* clazz) {
+  std::string n(&typeEncoding->details.interfaceDeclarationReference.name.value());
+  return n.compare(clazz) == 0;
 }
 
-// this is experimental. Maybe we can have something like this to wrap all Local<Value> to avoid extra v8 calls
+// this is experimental. Maybe we can have something like this to wrap all Local<Value> to avoid
+// extra v8 calls
 class ValueCache {
-    public:
-    enum IsOfType {
-        UNDEFINED,
-        TYPES_YES,
-        TYPE_NO
-    };
-    
-    inline bool isObject() {
-        if(this->_isObject == UNDEFINED) {
-            this->_isObject = this->_arg->IsObject() ? TYPES_YES : TYPE_NO;
-        }
-        return this->_isObject == TYPES_YES;
+ public:
+  enum IsOfType { UNDEFINED, TYPES_YES, TYPE_NO };
+
+  inline bool isObject() {
+    if (this->_isObject == UNDEFINED) {
+      this->_isObject = this->_arg->IsObject() ? TYPES_YES : TYPE_NO;
     }
-    
-    inline bool isString() {
-        if(this->_isString == UNDEFINED) {
-            this->_isString = tns::IsString(this->_arg) ? TYPES_YES : TYPE_NO;
-        }
-        return this->_isString == TYPES_YES;
+    return this->_isObject == TYPES_YES;
+  }
+
+  inline bool isString() {
+    if (this->_isString == UNDEFINED) {
+      this->_isString = tns::IsString(this->_arg) ? TYPES_YES : TYPE_NO;
     }
-    
-    inline bool isBool() {
-        if(this->_isBool == UNDEFINED) {
-            this->_isBool = tns::IsBool(this->_arg) ? TYPES_YES : TYPE_NO;
-        }
-        return this->_isBool == TYPES_YES;
+    return this->_isString == TYPES_YES;
+  }
+
+  inline bool isBool() {
+    if (this->_isBool == UNDEFINED) {
+      this->_isBool = tns::IsBool(this->_arg) ? TYPES_YES : TYPE_NO;
     }
-    
-    ValueCache(Local<Value>& arg) : _arg(arg) {
-        
-    };
-    
-    private:
-    Local<Value>& _arg;
-    IsOfType _isString = UNDEFINED;
-    IsOfType _isBool = UNDEFINED;
-    IsOfType _isObject = UNDEFINED;
+    return this->_isBool == TYPES_YES;
+  }
+
+  ValueCache(Local<Value>& arg)
+      : _arg(arg) {
+
+        };
+
+ private:
+  Local<Value>& _arg;
+  IsOfType _isString = UNDEFINED;
+  IsOfType _isBool = UNDEFINED;
+  IsOfType _isObject = UNDEFINED;
 };
 
-void Interop::WriteTypeValue(Local<Context> context, BaseDataWrapper* typeWrapper, void* dest, Local<Value> arg) {
-    Isolate* isolate = context->GetIsolate();
-    ValueCache argHelper(arg);
-    bool isEmptyOrUndefined = arg.IsEmpty() || arg->IsNullOrUndefined();
-    bool success = false;
-    
-    if (typeWrapper->Type() == WrapperType::StructType) {
-        if (isEmptyOrUndefined) {
-            StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
-            StructInfo structInfo = structTypeWrapper->StructInfo();
-            
-            memset(dest, 0, structInfo.FFIType()->size);
-            success = true;
-        } else if (argHelper.isObject()) {
-            BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-            if (wrapper != nullptr) {
-                if (wrapper->Type() == WrapperType::Struct) {
-                    StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-                    void* buffer = structWrapper->Data();
-                    size_t size = structWrapper->StructInfo().FFIType()->size;
-                    memcpy(dest, buffer, size);
-                    success = true;
-                }
-            } else {
-                // Create the structure using the struct initializer syntax
-                StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
-                StructInfo structInfo = structTypeWrapper->StructInfo();
-                Interop::InitializeStruct(context, dest, structInfo.Fields(), arg.As<Object>());
-                success = true;
-            }
+void Interop::WriteTypeValue(Local<Context> context, BaseDataWrapper* typeWrapper, void* dest,
+                             Local<Value> arg) {
+  Isolate* isolate = context->GetIsolate();
+  ValueCache argHelper(arg);
+  bool isEmptyOrUndefined = arg.IsEmpty() || arg->IsNullOrUndefined();
+  bool success = false;
+
+  if (typeWrapper->Type() == WrapperType::StructType) {
+    if (isEmptyOrUndefined) {
+      StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
+      StructInfo structInfo = structTypeWrapper->StructInfo();
+
+      memset(dest, 0, structInfo.FFIType()->size);
+      success = true;
+    } else if (argHelper.isObject()) {
+      BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+      if (wrapper != nullptr) {
+        if (wrapper->Type() == WrapperType::Struct) {
+          StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+          void* buffer = structWrapper->Data();
+          size_t size = structWrapper->StructInfo().FFIType()->size;
+          memcpy(dest, buffer, size);
+          success = true;
         }
+      } else {
+        // Create the structure using the struct initializer syntax
+        StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
+        StructInfo structInfo = structTypeWrapper->StructInfo();
+        Interop::InitializeStruct(context, dest, structInfo.Fields(), arg.As<Object>());
+        success = true;
+      }
     }
-    
-    if (!success) {
-        tns::Assert(false, isolate);
-    }
+  }
+
+  if (!success) {
+    tns::Assert(false, isolate);
+  }
 }
 
-void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncoding, void* dest, Local<Value> arg) {
-    Isolate* isolate = context->GetIsolate();
-    ExecuteWriteValueDebugValidationsIfInDebug(context, typeEncoding, dest, arg);
-    ValueCache argHelper(arg);
-    if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
-        ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding, true);
+void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncoding, void* dest,
+                         Local<Value> arg) {
+  Isolate* isolate = context->GetIsolate();
+  ExecuteWriteValueDebugValidationsIfInDebug(context, typeEncoding, dest, arg);
+  ValueCache argHelper(arg);
+  if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
+    ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding, true);
+    size_t size = ffiType->size;
+    FFICall::DisposeFFIType(ffiType, typeEncoding);
+    memset(dest, 0, size);
+  } else if (argHelper.isBool()) {
+    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference &&
+        isRefTypeEqual(typeEncoding, "NSNumber")) {
+      bool value = tns::ToBool(arg);
+      NSNumber* num = [NSNumber numberWithBool:value];
+      Interop::SetValue(dest, num);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::IdEncoding) {
+      bool value = tns::ToBool(arg);
+      NSObject* o = @(value);
+      Interop::SetValue(dest, o);
+    } else {
+      bool value = tns::ToBool(arg);
+      Interop::SetValue(dest, value);
+    }
+  } else if (argHelper.isString() &&
+             typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding) {
+    std::string str = tns::ToString(isolate, arg);
+    NSString* selStr = [NSString stringWithUTF8String:str.c_str()];
+    SEL selector = NSSelectorFromString(selStr);
+    Interop::SetValue(dest, selector);
+  } else if (typeEncoding->type == BinaryTypeEncodingType::CStringEncoding) {
+    if (arg->IsString()) {
+      const char* value = nullptr;
+      Local<v8::String> strArg = arg.As<v8::String>();
+      if (strArg->IsExternalOneByte()) {
+        const v8::String::ExternalOneByteStringResource* resource =
+            strArg->GetExternalOneByteStringResource();
+        value = resource->data();
+      } else {
+        v8::String::Utf8Value utf8Value(isolate, arg);
+        value = strdup(*utf8Value);
+        auto length = strArg->Length() + 1;
+        OneByteStringResource* resource = new OneByteStringResource(value, length);
+        bool success = v8::String::NewExternalOneByte(isolate, resource).ToLocal(&arg);
+        tns::Assert(success, isolate);
+      }
+      Interop::SetValue(dest, value);
+    } else {
+      BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+      if (wrapper == nullptr) {
+        bool isArrayBuffer = false;
+        void* data = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
+        if (isArrayBuffer) {
+          Interop::SetValue(dest, data);
+          return;
+        }
+      }
+
+      tns::Assert(wrapper != nullptr, isolate);
+      if (wrapper->Type() == WrapperType::Pointer) {
+        PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
+        void* data = pw->Data();
+        Interop::SetValue(dest, data);
+      } else if (wrapper->Type() == WrapperType::Reference) {
+        ReferenceWrapper* refWrapper = static_cast<ReferenceWrapper*>(wrapper);
+        tns::Assert(refWrapper->Value() != nullptr, isolate);
+        Local<Value> value = refWrapper->Value()->Get(isolate);
+        wrapper = tns::GetValue(isolate, value);
+        tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::Pointer, isolate);
+        PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
+        void* data = pw->Data();
+        Interop::SetValue(dest, data);
+      } else {
+        // Unsupported wrapprt type for CString
+        tns::Assert(false, isolate);
+      }
+    }
+  } else if (argHelper.isString() &&
+             typeEncoding->type == BinaryTypeEncodingType::UnicharEncoding) {
+    v8::String::Utf8Value utf8Value(isolate, arg);
+    std::vector<uint16_t> vector = tns::ToVector(*utf8Value);
+    if (vector.size() > 1) {
+      throw NativeScriptException("Only one character string can be converted to unichar.");
+    }
+    unichar c = (vector.size() == 0) ? 0 : vector[0];
+    Interop::SetValue(dest, c);
+  } else if (argHelper.isString() &&
+             (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+              typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
+    NSString* result = tns::ToNSString(isolate, arg);
+    Interop::SetValue(dest, result);
+  } else if (Interop::IsNumbericType(typeEncoding->type) || tns::IsNumber(arg)) {
+    double value = tns::ToNumber(isolate, arg);
+
+    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+        typeEncoding->type == BinaryTypeEncodingType::IdEncoding) {
+      // NSNumber
+      NSNumber* num = [NSNumber numberWithDouble:value];
+      Interop::SetValue(dest, num);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::UShortEncoding) {
+      Interop::SetNumericValue<unsigned short>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::ShortEncoding) {
+      Interop::SetNumericValue<short>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::UIntEncoding) {
+      Interop::SetNumericValue<unsigned int>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::IntEncoding) {
+      Interop::SetNumericValue<int>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::ULongEncoding) {
+      Interop::SetNumericValue<unsigned long>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::LongEncoding) {
+      Interop::SetNumericValue<long>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::ULongLongEncoding) {
+      Interop::SetNumericValue<unsigned long long>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::LongLongEncoding) {
+      Interop::SetNumericValue<long long>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::FloatEncoding) {
+      Interop::SetNumericValue<float>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::DoubleEncoding) {
+      Interop::SetNumericValue<double>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::UCharEncoding) {
+      Interop::SetNumericValue<unsigned char>(dest, value);
+    } else if (typeEncoding->type == BinaryTypeEncodingType::CharEncoding) {
+      Interop::SetNumericValue<char>(dest, value);
+    } else {
+      tns::Assert(false, isolate);
+    }
+  } else if (typeEncoding->type == BinaryTypeEncodingType::ExtVectorEncoding) {
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+    tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ExtVector, isolate);
+    ExtVectorWrapper* extVectorWrapper = static_cast<ExtVectorWrapper*>(wrapper);
+    void* data = extVectorWrapper->Data();
+    size_t size = extVectorWrapper->FFIType()->size;
+    memcpy(dest, data, size);
+  } else if (typeEncoding->type == BinaryTypeEncodingType::PointerEncoding) {
+    const TypeEncoding* innerType = typeEncoding->details.pointer.getInnerType();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+    if (innerType->type == BinaryTypeEncodingType::VoidEncoding) {
+      bool isArrayBuffer = false;
+      void* buffer = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
+      if (isArrayBuffer) {
+        Interop::SetValue(dest, buffer);
+        return;
+      }
+
+      tns::Assert(wrapper != nullptr, isolate);
+
+      if (wrapper->Type() == WrapperType::Pointer) {
+        PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+        void* data = pointerWrapper->Data();
+        Interop::SetValue(dest, data);
+      } else if (wrapper->Type() == WrapperType::Reference) {
+        void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
+        Interop::SetValue(dest, data);
+      } else {
+        // TODO:
+        tns::Assert(false, isolate);
+      }
+    } else {
+      void* data = nullptr;
+
+      if (wrapper == nullptr &&
+          innerType->type == BinaryTypeEncodingType::StructDeclarationReference) {
+        const Meta* meta =
+            ArgConverter::GetMeta(innerType->details.declarationReference.name.valuePtr());
+        tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
+        const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
+        StructInfo structInfo = FFICall::GetStructInfo(structMeta);
+        // TODO: How to free this?
+        // this is used when you have js obj and wants to pass the data as a struct ponter
+        // (MyStruct*) we create a new MyStruct with a snapshot of the jsObject and pass that in but
+        // when should we delete it? currently it's up to the function called to delete it we could
+        // delete after the function call, but if the fuction stores that then it's a memory leak we
+        // could also just store it as a wrapper in the object, binding it to the object lifecycle
+        // but that also means refactoring a lot of "if(wrapper == nullptr)" because essentially the
+        // wrapper should be treated as a nullptr, except when deating with
+        // StructDeclarationReference
+        data = malloc(structInfo.FFIType()->size);
+        Interop::InitializeStruct(context, data, structInfo.Fields(), arg);
+      } else {
+        if (wrapper == nullptr) {
+          bool isArrayBuffer = false;
+          void* data = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
+          if (isArrayBuffer) {
+            Interop::SetValue(dest, data);
+            return;
+          }
+        }
+
+        tns::Assert(wrapper != nullptr, isolate);
+
+        if (wrapper->Type() == WrapperType::Pointer) {
+          PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+          data = pointerWrapper->Data();
+        } else if (wrapper->Type() == WrapperType::Reference) {
+          ReferenceWrapper* referenceWrapper = static_cast<ReferenceWrapper*>(wrapper);
+          Local<Value> value = referenceWrapper->Value() != nullptr
+                                   ? referenceWrapper->Value()->Get(isolate)
+                                   : Local<Value>();
+          ffi_type* ffiType = FFICall::GetArgumentType(innerType);
+          data = calloc(1, ffiType->size);
+          FFICall::DisposeFFIType(ffiType, innerType);
+
+          referenceWrapper->SetData(data, true);
+          referenceWrapper->SetEncoding(innerType);
+
+          // Initialize the ref/out parameter value before passing it to the function call
+          if (!value.IsEmpty()) {
+            Interop::WriteValue(context, innerType, data, value);
+          }
+        } else if (wrapper->Type() == WrapperType::Struct) {
+          StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+          data = structWrapper->Data();
+        } else {
+          tns::Assert(false, isolate);
+        }
+      }
+
+      Interop::SetValue(dest, data);
+    }
+  } else if (argHelper.isObject() &&
+             typeEncoding->type == BinaryTypeEncodingType::FunctionPointerEncoding) {
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, arg.As<Object>());
+    tns::Assert(wrapper != nullptr, isolate);
+    if (wrapper->Type() == WrapperType::Pointer) {
+      PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+      void* data = pointerWrapper->Data();
+      Interop::SetValue(dest, data);
+    } else if (wrapper->Type() == WrapperType::AnonymousFunction) {
+      AnonymousFunctionWrapper* functionWrapper = static_cast<AnonymousFunctionWrapper*>(wrapper);
+      void* data = functionWrapper->Data();
+      Interop::SetValue(dest, data);
+    } else if (wrapper->Type() == WrapperType::FunctionReference) {
+      tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::FunctionReference, isolate);
+      FunctionReferenceWrapper* funcWrapper = static_cast<FunctionReferenceWrapper*>(wrapper);
+      const TypeEncoding* functionTypeEncoding =
+          typeEncoding->details.functionPointer.signature.first();
+      int argsCount = typeEncoding->details.functionPointer.signature.count - 1;
+
+      Local<Value> callbackValue = funcWrapper->Function()->Get(isolate);
+      tns::Assert(callbackValue->IsFunction(), isolate);
+      Local<v8::Function> callback = callbackValue.As<v8::Function>();
+      std::shared_ptr<Persistent<Value>> poCallback =
+          std::make_shared<Persistent<Value>>(isolate, callback);
+      MethodCallbackWrapper* userData =
+          new MethodCallbackWrapper(isolate, poCallback, 0, argsCount, functionTypeEncoding);
+
+      void* functionPointer = (void*)Interop::CreateMethod(0, argsCount, functionTypeEncoding,
+                                                           ArgConverter::MethodCallback, userData);
+
+      funcWrapper->SetData(functionPointer);
+
+      Interop::SetValue(dest, functionPointer);
+    } else {
+      tns::Assert(false, isolate);
+    }
+  } else if (arg->IsFunction() && typeEncoding->type == BinaryTypeEncodingType::BlockEncoding) {
+    const TypeEncoding* blockTypeEncoding = typeEncoding->details.block.signature.first();
+    int argsCount = typeEncoding->details.block.signature.count - 1;
+
+    CFTypeRef blockPtr = nullptr;
+    BaseDataWrapper* baseWrapper = tns::GetValue(isolate, arg);
+    if (baseWrapper != nullptr && baseWrapper->Type() == WrapperType::Block) {
+      BlockWrapper* wrapper = static_cast<BlockWrapper*>(baseWrapper);
+      blockPtr = Block_copy(wrapper->Block());
+    } else {
+      std::shared_ptr<Persistent<Value>> poCallback =
+          std::make_shared<Persistent<Value>>(isolate, arg);
+      MethodCallbackWrapper* userData =
+          new MethodCallbackWrapper(isolate, poCallback, 1, argsCount, blockTypeEncoding);
+      blockPtr = Interop::CreateBlock(1, argsCount, blockTypeEncoding, ArgConverter::MethodCallback,
+                                      userData);
+
+      BlockWrapper* wrapper = new BlockWrapper((void*)blockPtr, blockTypeEncoding, false);
+      tns::SetValue(isolate, arg.As<v8::Function>(), wrapper);
+    }
+
+    Interop::SetValue(dest, blockPtr);
+  } else if (argHelper.isObject() &&
+             typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
+    Local<Object> obj = arg.As<Object>();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+    if (wrapper != nullptr) {
+      if (wrapper->Type() == WrapperType::Struct) {
+        StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+        void* buffer = structWrapper->Data();
+        size_t size = structWrapper->StructInfo().FFIType()->size;
+        memcpy(dest, buffer, size);
+      } else if (wrapper->Type() == WrapperType::Reference) {
+        void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
+        tns::Assert(data != nullptr, isolate);
+        ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding);
         size_t size = ffiType->size;
         FFICall::DisposeFFIType(ffiType, typeEncoding);
-        memset(dest, 0, size);
-    } else if (argHelper.isBool()) {
-        if(typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference && isRefTypeEqual(typeEncoding, "NSNumber")) {
-            bool value = tns::ToBool(arg);
-            NSNumber *num = [NSNumber numberWithBool: value];
-            Interop::SetValue(dest, num);
-        } else if(typeEncoding->type == BinaryTypeEncodingType::IdEncoding) {
-            bool value = tns::ToBool(arg);
-            NSObject* o = @(value);
-            Interop::SetValue(dest, o);
-        } else {
-            bool value = tns::ToBool(arg);
-            Interop::SetValue(dest, value);
-        }
-    } else if (argHelper.isString() && typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding) {
-        std::string str = tns::ToString(isolate, arg);
-        NSString* selStr = [NSString stringWithUTF8String:str.c_str()];
-        SEL selector = NSSelectorFromString(selStr);
-        Interop::SetValue(dest, selector);
-    } else if (typeEncoding->type == BinaryTypeEncodingType::CStringEncoding) {
-        if (arg->IsString()) {
-            const char* value = nullptr;
-            Local<v8::String> strArg = arg.As<v8::String>();
-            if (strArg->IsExternalOneByte()) {
-                const v8::String::ExternalOneByteStringResource* resource = strArg->GetExternalOneByteStringResource();
-                value = resource->data();
-            } else {
-                v8::String::Utf8Value utf8Value(isolate, arg);
-                value = strdup(*utf8Value);
-                auto length = strArg->Length() + 1;
-                OneByteStringResource* resource = new OneByteStringResource(value, length);
-                bool success = v8::String::NewExternalOneByte(isolate, resource).ToLocal(&arg);
-                tns::Assert(success, isolate);
-            }
-            Interop::SetValue(dest, value);
-        } else {
-            BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-            if (wrapper == nullptr) {
-                bool isArrayBuffer = false;
-                void* data = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
-                if (isArrayBuffer) {
-                    Interop::SetValue(dest, data);
-                    return;
-                }
-            }
-
-            tns::Assert(wrapper != nullptr, isolate);
-            if (wrapper->Type() == WrapperType::Pointer) {
-                PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
-                void* data = pw->Data();
-                Interop::SetValue(dest, data);
-            } else if (wrapper->Type() == WrapperType::Reference) {
-                ReferenceWrapper* refWrapper = static_cast<ReferenceWrapper*>(wrapper);
-                tns::Assert(refWrapper->Value() != nullptr, isolate);
-                Local<Value> value = refWrapper->Value()->Get(isolate);
-                wrapper = tns::GetValue(isolate, value);
-                tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::Pointer, isolate);
-                PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
-                void* data = pw->Data();
-                Interop::SetValue(dest, data);
-            } else {
-                // Unsupported wrapprt type for CString
-                tns::Assert(false, isolate);
-            }
-        }
-    } else if (argHelper.isString() && typeEncoding->type == BinaryTypeEncodingType::UnicharEncoding) {
-        v8::String::Utf8Value utf8Value(isolate, arg);
-        std::vector<uint16_t> vector = tns::ToVector(*utf8Value);
-        if (vector.size() > 1) {
-            throw NativeScriptException("Only one character string can be converted to unichar.");
-        }
-        unichar c = (vector.size() == 0) ? 0 : vector[0];
-        Interop::SetValue(dest, c);
-    } else if (argHelper.isString() && (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference || typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
-        NSString* result = tns::ToNSString(isolate, arg);
-        Interop::SetValue(dest, result);
-    } else if (Interop::IsNumbericType(typeEncoding->type) || tns::IsNumber(arg)) {
-        double value = tns::ToNumber(isolate, arg);
-
-        if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference || typeEncoding->type == BinaryTypeEncodingType::IdEncoding) {
-            // NSNumber
-            NSNumber* num = [NSNumber numberWithDouble:value];
-            Interop::SetValue(dest, num);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::UShortEncoding) {
-            Interop::SetNumericValue<unsigned short>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::ShortEncoding) {
-            Interop::SetNumericValue<short>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::UIntEncoding) {
-            Interop::SetNumericValue<unsigned int>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::IntEncoding) {
-            Interop::SetNumericValue<int>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::ULongEncoding) {
-            Interop::SetNumericValue<unsigned long>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::LongEncoding) {
-            Interop::SetNumericValue<long>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::ULongLongEncoding) {
-            Interop::SetNumericValue<unsigned long long>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::LongLongEncoding) {
-            Interop::SetNumericValue<long long>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::FloatEncoding) {
-            Interop::SetNumericValue<float>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::DoubleEncoding) {
-            Interop::SetNumericValue<double>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::UCharEncoding) {
-            Interop::SetNumericValue<unsigned char>(dest, value);
-        } else if (typeEncoding->type == BinaryTypeEncodingType::CharEncoding) {
-            Interop::SetNumericValue<char>(dest, value);
-        } else {
-            tns::Assert(false, isolate);
-        }
-    } else if (typeEncoding->type == BinaryTypeEncodingType::ExtVectorEncoding) {
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ExtVector, isolate);
-        ExtVectorWrapper* extVectorWrapper = static_cast<ExtVectorWrapper*>(wrapper);
-        void* data = extVectorWrapper->Data();
-        size_t size = extVectorWrapper->FFIType()->size;
         memcpy(dest, data, size);
-    } else if (typeEncoding->type == BinaryTypeEncodingType::PointerEncoding) {
-        const TypeEncoding* innerType = typeEncoding->details.pointer.getInnerType();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        if (innerType->type == BinaryTypeEncodingType::VoidEncoding) {
-            bool isArrayBuffer = false;
-            void* buffer = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
-            if (isArrayBuffer) {
-                Interop::SetValue(dest, buffer);
-                return;
-            }
-
-            tns::Assert(wrapper != nullptr, isolate);
-
-            if (wrapper->Type() == WrapperType::Pointer) {
-                PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-                void* data = pointerWrapper->Data();
-                Interop::SetValue(dest, data);
-            } else if (wrapper->Type() == WrapperType::Reference) {
-                void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
-                Interop::SetValue(dest, data);
-            } else {
-                // TODO:
-                tns::Assert(false, isolate);
-            }
-        } else {
-            void* data = nullptr;
-
-            if (wrapper == nullptr && innerType->type == BinaryTypeEncodingType::StructDeclarationReference) {
-                const Meta* meta = ArgConverter::GetMeta(innerType->details.declarationReference.name.valuePtr());
-                tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
-                const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
-                StructInfo structInfo = FFICall::GetStructInfo(structMeta);
-                // TODO: How to free this?
-                // this is used when you have js obj and wants to pass the data as a struct ponter (MyStruct*)
-                // we create a new MyStruct with a snapshot of the jsObject and pass that in
-                // but when should we delete it?
-                // currently it's up to the function called to delete it
-                // we could delete after the function call, but if the fuction stores that then it's a memory leak
-                // we could also just store it as a wrapper in the object, binding it to the object lifecycle
-                // but that also means refactoring a lot of "if(wrapper == nullptr)" because essentially the wrapper
-                // should be treated as a nullptr, except when deating with StructDeclarationReference
-                data = malloc(structInfo.FFIType()->size);
-                Interop::InitializeStruct(context, data, structInfo.Fields(), arg);
-            } else {
-                if (wrapper == nullptr) {
-                    bool isArrayBuffer = false;
-                    void* data = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
-                    if (isArrayBuffer) {
-                        Interop::SetValue(dest, data);
-                        return;
-                    }
-                }
-
-                tns::Assert(wrapper != nullptr, isolate);
-
-                if (wrapper->Type() == WrapperType::Pointer) {
-                    PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-                    data = pointerWrapper->Data();
-                } else if (wrapper->Type() == WrapperType::Reference) {
-                    ReferenceWrapper* referenceWrapper = static_cast<ReferenceWrapper*>(wrapper);
-                    Local<Value> value = referenceWrapper->Value() != nullptr ? referenceWrapper->Value()->Get(isolate) : Local<Value>();
-                    ffi_type* ffiType = FFICall::GetArgumentType(innerType);
-                    data = calloc(1, ffiType->size);
-                    FFICall::DisposeFFIType(ffiType, innerType);
-
-                    referenceWrapper->SetData(data, true);
-                    referenceWrapper->SetEncoding(innerType);
-
-                    // Initialize the ref/out parameter value before passing it to the function call
-                    if (!value.IsEmpty()) {
-                        Interop::WriteValue(context, innerType, data, value);
-                    }
-                } else if (wrapper->Type() == WrapperType::Struct) {
-                    StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-                    data = structWrapper->Data();
-                } else {
-                    tns::Assert(false, isolate);
-                }
-            }
-
-            Interop::SetValue(dest, data);
-        }
-    } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::FunctionPointerEncoding) {
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg.As<Object>());
-        tns::Assert(wrapper != nullptr, isolate);
-        if (wrapper->Type() == WrapperType::Pointer) {
-            PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-            void* data = pointerWrapper->Data();
-            Interop::SetValue(dest, data);
-        } else if (wrapper->Type() == WrapperType::AnonymousFunction) {
-            AnonymousFunctionWrapper* functionWrapper = static_cast<AnonymousFunctionWrapper*>(wrapper);
-            void* data = functionWrapper->Data();
-            Interop::SetValue(dest, data);
-        } else if (wrapper->Type() == WrapperType::FunctionReference) {
-            tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::FunctionReference, isolate);
-            FunctionReferenceWrapper* funcWrapper = static_cast<FunctionReferenceWrapper*>(wrapper);
-            const TypeEncoding* functionTypeEncoding = typeEncoding->details.functionPointer.signature.first();
-            int argsCount = typeEncoding->details.functionPointer.signature.count - 1;
-
-            Local<Value> callbackValue = funcWrapper->Function()->Get(isolate);
-            tns::Assert(callbackValue->IsFunction(), isolate);
-            Local<v8::Function> callback = callbackValue.As<v8::Function>();
-            std::shared_ptr<Persistent<Value>> poCallback = std::make_shared<Persistent<Value>>(isolate, callback);
-            MethodCallbackWrapper* userData = new MethodCallbackWrapper(isolate, poCallback, 0, argsCount, functionTypeEncoding);
-
-            void* functionPointer = (void*)Interop::CreateMethod(0, argsCount, functionTypeEncoding, ArgConverter::MethodCallback, userData);
-
-            funcWrapper->SetData(functionPointer);
-
-            Interop::SetValue(dest, functionPointer);
-        } else {
-            tns::Assert(false, isolate);
-        }
-    } else if (arg->IsFunction() && typeEncoding->type == BinaryTypeEncodingType::BlockEncoding) {
-        const TypeEncoding* blockTypeEncoding = typeEncoding->details.block.signature.first();
-        int argsCount = typeEncoding->details.block.signature.count - 1;
-
-        CFTypeRef blockPtr = nullptr;
-        BaseDataWrapper* baseWrapper = tns::GetValue(isolate, arg);
-        if (baseWrapper != nullptr && baseWrapper->Type() == WrapperType::Block) {
-            BlockWrapper* wrapper = static_cast<BlockWrapper*>(baseWrapper);
-            blockPtr = Block_copy(wrapper->Block());
-        } else {
-            std::shared_ptr<Persistent<Value>> poCallback = std::make_shared<Persistent<Value>>(isolate, arg);
-            MethodCallbackWrapper* userData = new MethodCallbackWrapper(isolate, poCallback, 1, argsCount, blockTypeEncoding);
-            blockPtr = Interop::CreateBlock(1, argsCount, blockTypeEncoding, ArgConverter::MethodCallback, userData);
-
-            BlockWrapper* wrapper = new BlockWrapper((void*)blockPtr, blockTypeEncoding, false);
-            tns::SetValue(isolate, arg.As<v8::Function>(), wrapper);
-        }
-
-        Interop::SetValue(dest, blockPtr);
-    } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
-        Local<Object> obj = arg.As<Object>();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        if (wrapper != nullptr) {
-            if (wrapper->Type() == WrapperType::Struct) {
-                StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-                void* buffer = structWrapper->Data();
-                size_t size = structWrapper->StructInfo().FFIType()->size;
-                memcpy(dest, buffer, size);
-            } else if (wrapper->Type() == WrapperType::Reference) {
-                void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
-                tns::Assert(data != nullptr, isolate);
-                ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding);
-                size_t size = ffiType->size;
-                FFICall::DisposeFFIType(ffiType, typeEncoding);
-                memcpy(dest, data, size);
-            } else {
-                tns::Assert(false, isolate);
-            }
-        } else {
-            // Create the structure using the struct initializer syntax
-            const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
-            const Meta* meta = ArgConverter::GetMeta(structName);
-            tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
-            const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
-            StructInfo structInfo = FFICall::GetStructInfo(structMeta);
-            Interop::InitializeStruct(context, dest, structInfo.Fields(), obj);
-        }
-    } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::AnonymousStructEncoding) {
-        Local<Object> obj = arg.As<Object>();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        if (wrapper != nullptr && wrapper->Type() == WrapperType::Struct) {
-            size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
-            const TypeEncoding* fieldEncoding = typeEncoding->details.anonymousRecord.getFieldsEncodings();
-            const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
-            StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
-
-            StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-            void* data = structWrapper->Data();
-            size_t size = structInfo.FFIType()->size;
-            memcpy(dest, data, size);
-        } else {
-            // Anonymous structs can only be initialized with plain javascript objects
-            tns::Assert(wrapper == nullptr, isolate);
-            size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
-            const TypeEncoding* fieldEncoding = typeEncoding->details.anonymousRecord.getFieldsEncodings();
-            const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
-            StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
-            Interop::InitializeStruct(context, dest, structInfo.Fields(), obj);
-        }
-    } else if (arg->IsFunction() && typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding) {
-        Local<Object> obj = arg.As<Object>();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
-        tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCProtocol, isolate);
-        ObjCProtocolWrapper* protoWrapper = static_cast<ObjCProtocolWrapper*>(wrapper);
-        Protocol* proto = protoWrapper->Proto();
-        Interop::SetValue(dest, proto);
-    } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
-        Local<Object> obj = arg.As<Object>();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
-        tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass, isolate);
-        ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
-        Class clazz = classWrapper->Klass();
-        Interop::SetValue(dest, clazz);
-    } else if (arg->IsDate()) {
-        Local<Date> date = arg.As<Date>();
-        double time = date->ValueOf();
-        NSDate* nsDate = [NSDate dateWithTimeIntervalSince1970:(time / 1000)];
-        Interop::SetValue(dest, nsDate);
-    } else if (typeEncoding->type == BinaryTypeEncodingType::IncompleteArrayEncoding) {
-        void* data = nullptr;
-        if (arg->IsArrayBuffer()) {
-            std::shared_ptr<BackingStore> backingStore = arg.As<ArrayBuffer>()->GetBackingStore();
-            data = backingStore->Data();
-        } else if (arg->IsArrayBufferView()) {
-            std::shared_ptr<BackingStore> backingStore = arg.As<ArrayBufferView>()->Buffer()->GetBackingStore();
-            data = backingStore->Data();
-        } else {
-            data = Reference::GetWrappedPointer(context, arg, typeEncoding);
-        }
-        Interop::SetValue(dest, data);
-    } else if (typeEncoding->type == BinaryTypeEncodingType::ConstantArrayEncoding) {
-        if (arg->IsArray()) {
-            Local<v8::Array> array = arg.As<v8::Array>();
-            Local<Context> context = isolate->GetCurrentContext();
-            const TypeEncoding* innerType = typeEncoding->details.constantArray.getInnerType();
-            ffi_type* ffiType = FFICall::GetArgumentType(innerType);
-            uint32_t length = array->Length();
-            for (uint32_t i = 0; i < length; i++) {
-                Local<Value> element;
-                bool success = array->Get(context, i).ToLocal(&element);
-                tns::Assert(success, isolate);
-                void* ptr = (uint8_t*)dest + i * ffiType->size;
-                Interop::WriteValue(context, innerType, ptr, element);
-            }
-            FFICall::DisposeFFIType(ffiType, innerType);
-        } else {
-            void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
-            Interop::SetValue(dest, data);
-        }
-    } else if (argHelper.isObject()) {
-        Local<Object> obj = arg.As<Object>();
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
-
-        if (wrapper != nullptr) {
-            if (wrapper->Type() == WrapperType::Enum) {
-                EnumDataWrapper* enumWrapper = static_cast<EnumDataWrapper*>(wrapper);
-                Local<Context> context = isolate->GetCurrentContext();
-                std::string jsCode = enumWrapper->JSCode();
-                Local<Script> script;
-                if (!Script::Compile(context, tns::ToV8String(isolate, jsCode)).ToLocal(&script)) {
-                    tns::Assert(false, isolate);
-                }
-                tns::Assert(!script.IsEmpty(), isolate);
-
-                Local<Value> result;
-                if (!script->Run(context).ToLocal(&result) && !result.IsEmpty()) {
-                    tns::Assert(false, isolate);
-                }
-
-                tns::Assert(result->IsNumber(), isolate);
-
-                double value = result.As<Number>()->Value();
-                SetValue(dest, value);
-            } else if (wrapper->Type() == WrapperType::Pointer) {
-                PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-                void* data = pointerWrapper->Data();
-                Interop::SetValue(dest, data);
-            } else if (wrapper->Type() == WrapperType::ObjCObject) {
-                ObjCDataWrapper* objCDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                id data = objCDataWrapper->Data();
-                Interop::SetValue(dest, data);
-            } else if (wrapper->Type() == WrapperType::ObjCClass) {
-                ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
-                id data = classWrapper->Klass();
-                Interop::SetValue(dest, data);
-            } else {
-                tns::Assert(false, isolate);
-            }
-
-            return;
-        }
-
-        bool isNSArray = false;
-        if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-            std::string name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
-            isNSArray = name == "NSArray";
-        }
-
-        if ((obj->IsArrayBuffer() || obj->IsArrayBufferView()) && !isNSArray) {
-            Local<ArrayBuffer> buffer = arg.As<ArrayBuffer>();
-            NSDataAdapter* adapter = [[NSDataAdapter alloc] initWithJSObject:buffer isolate:isolate];
-            Interop::SetValue(dest, CFBridgingRelease(adapter));
-            // CFAutorelease(adapter);
-        } else if (tns::IsArrayOrArrayLike(isolate, obj)) {
-            Local<v8::Array> array = Interop::ToArray(obj);
-            ArrayAdapter* adapter = [[ArrayAdapter alloc] initWithJSObject:array isolate:isolate];
-            Interop::SetValue(dest, CFBridgingRelease(adapter));
-            // CFAutorelease(adapter);
-        } else {
-            DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
-            Interop::SetValue(dest, CFBridgingRelease(adapter));
-            // CFAutorelease(adapter);
-        }
-    } else {
+      } else {
         tns::Assert(false, isolate);
+      }
+    } else {
+      // Create the structure using the struct initializer syntax
+      const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
+      const Meta* meta = ArgConverter::GetMeta(structName);
+      tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
+      const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
+      StructInfo structInfo = FFICall::GetStructInfo(structMeta);
+      Interop::InitializeStruct(context, dest, structInfo.Fields(), obj);
     }
+  } else if (argHelper.isObject() &&
+             typeEncoding->type == BinaryTypeEncodingType::AnonymousStructEncoding) {
+    Local<Object> obj = arg.As<Object>();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+    if (wrapper != nullptr && wrapper->Type() == WrapperType::Struct) {
+      size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
+      const TypeEncoding* fieldEncoding =
+          typeEncoding->details.anonymousRecord.getFieldsEncodings();
+      const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
+      StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
+
+      StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+      void* data = structWrapper->Data();
+      size_t size = structInfo.FFIType()->size;
+      memcpy(dest, data, size);
+    } else {
+      // Anonymous structs can only be initialized with plain javascript objects
+      tns::Assert(wrapper == nullptr, isolate);
+      size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
+      const TypeEncoding* fieldEncoding =
+          typeEncoding->details.anonymousRecord.getFieldsEncodings();
+      const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
+      StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
+      Interop::InitializeStruct(context, dest, structInfo.Fields(), obj);
+    }
+  } else if (arg->IsFunction() && typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding) {
+    Local<Object> obj = arg.As<Object>();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
+    tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCProtocol, isolate);
+    ObjCProtocolWrapper* protoWrapper = static_cast<ObjCProtocolWrapper*>(wrapper);
+    Protocol* proto = protoWrapper->Proto();
+    Interop::SetValue(dest, proto);
+  } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
+    Local<Object> obj = arg.As<Object>();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
+    tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass, isolate);
+    ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
+    Class clazz = classWrapper->Klass();
+    Interop::SetValue(dest, clazz);
+  } else if (arg->IsDate()) {
+    Local<Date> date = arg.As<Date>();
+    double time = date->ValueOf();
+    NSDate* nsDate = [NSDate dateWithTimeIntervalSince1970:(time / 1000)];
+    Interop::SetValue(dest, nsDate);
+  } else if (typeEncoding->type == BinaryTypeEncodingType::IncompleteArrayEncoding) {
+    bool isArrayBuffer = false;
+    void* data = tns::TryGetBufferFromArrayBuffer(arg, isArrayBuffer);
+    if (!isArrayBuffer) {
+      data = Reference::GetWrappedPointer(context, arg, typeEncoding);
+    }
+    Interop::SetValue(dest, data);
+  } else if (typeEncoding->type == BinaryTypeEncodingType::ConstantArrayEncoding) {
+    if (arg->IsArray()) {
+      Local<v8::Array> array = arg.As<v8::Array>();
+      Local<Context> context = isolate->GetCurrentContext();
+      const TypeEncoding* innerType = typeEncoding->details.constantArray.getInnerType();
+      ffi_type* ffiType = FFICall::GetArgumentType(innerType);
+      uint32_t length = array->Length();
+      for (uint32_t i = 0; i < length; i++) {
+        Local<Value> element;
+        bool success = array->Get(context, i).ToLocal(&element);
+        tns::Assert(success, isolate);
+        void* ptr = (uint8_t*)dest + i * ffiType->size;
+        Interop::WriteValue(context, innerType, ptr, element);
+      }
+      FFICall::DisposeFFIType(ffiType, innerType);
+    } else {
+      void* data = Reference::GetWrappedPointer(context, arg, typeEncoding);
+      Interop::SetValue(dest, data);
+    }
+  } else if (argHelper.isObject()) {
+    Local<Object> obj = arg.As<Object>();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
+
+    if (wrapper != nullptr) {
+      if (wrapper->Type() == WrapperType::Enum) {
+        EnumDataWrapper* enumWrapper = static_cast<EnumDataWrapper*>(wrapper);
+        Local<Context> context = isolate->GetCurrentContext();
+        std::string jsCode = enumWrapper->JSCode();
+        Local<Script> script;
+        if (!Script::Compile(context, tns::ToV8String(isolate, jsCode)).ToLocal(&script)) {
+          tns::Assert(false, isolate);
+        }
+        tns::Assert(!script.IsEmpty(), isolate);
+
+        Local<Value> result;
+        if (!script->Run(context).ToLocal(&result) && !result.IsEmpty()) {
+          tns::Assert(false, isolate);
+        }
+
+        tns::Assert(result->IsNumber(), isolate);
+
+        double value = result.As<Number>()->Value();
+        SetValue(dest, value);
+      } else if (wrapper->Type() == WrapperType::Pointer) {
+        PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+        void* data = pointerWrapper->Data();
+        Interop::SetValue(dest, data);
+      } else if (wrapper->Type() == WrapperType::ObjCObject) {
+        ObjCDataWrapper* objCDataWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+        id data = objCDataWrapper->Data();
+        Interop::SetValue(dest, data);
+      } else if (wrapper->Type() == WrapperType::ObjCClass) {
+        ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
+        id data = classWrapper->Klass();
+        Interop::SetValue(dest, data);
+      } else {
+        tns::Assert(false, isolate);
+      }
+
+      return;
+    }
+
+    bool isNSArray = false;
+    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+      std::string name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+      isNSArray = name == "NSArray";
+    }
+
+    if ((obj->IsArrayBuffer() || obj->IsArrayBufferView() || obj->IsSharedArrayBuffer()) &&
+        !isNSArray) {
+      Local<ArrayBuffer> buffer = arg.As<ArrayBuffer>();
+      NSDataAdapter* adapter = [[NSDataAdapter alloc] initWithJSObject:buffer isolate:isolate];
+      Interop::SetValue(dest, CFBridgingRelease(adapter));
+      // CFAutorelease(adapter);
+    } else if (tns::IsArrayOrArrayLike(isolate, obj)) {
+      Local<v8::Array> array = Interop::ToArray(obj);
+      ArrayAdapter* adapter = [[ArrayAdapter alloc] initWithJSObject:array isolate:isolate];
+      Interop::SetValue(dest, CFBridgingRelease(adapter));
+      // CFAutorelease(adapter);
+    } else {
+      DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
+      Interop::SetValue(dest, CFBridgingRelease(adapter));
+      // CFAutorelease(adapter);
+    }
+  } else {
+    tns::Assert(false, isolate);
+  }
 }
 
 id Interop::ToObject(Local<Context> context, v8::Local<v8::Value> arg) {
-    Isolate* isolate = context->GetIsolate();
-    if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
-        return nil;
-    } else if (tns::IsString(arg)) {
-        NSString* result = tns::ToNSString(isolate, arg);
-        return result;
-    } else if (tns::IsNumber(arg)) {
-        double value = tns::ToNumber(isolate, arg);
-        return @(value);
-    } else if (arg->IsDate()) {
-        Local<Date> date = arg.As<Date>();
-        double time = date->ValueOf();
-        NSDate* nsDate = [NSDate dateWithTimeIntervalSince1970:(time / 1000)];
-        return nsDate;
-    } else if (tns::IsBool(arg)) {
-        bool value = tns::ToBool(arg);
-        return @(value);
-    } else if (arg->IsArray()) {
-        Local<Object> obj = arg.As<Object>();
-        ArrayAdapter* adapter = [[ArrayAdapter alloc] initWithJSObject:obj isolate:isolate];
-        return adapter;
-    } else if (arg->IsObject()) {
-        if (BaseDataWrapper* wrapper = tns::GetValue(isolate, arg)) {
-            switch (wrapper->Type()) {
-                case WrapperType::ObjCObject: {
-                    ObjCDataWrapper* wr = static_cast<ObjCDataWrapper*>(wrapper);
-                    return wr->Data();
-                    break;
-                }
-                case WrapperType::ObjCClass: {
-                    ObjCClassWrapper* wr = static_cast<ObjCClassWrapper*>(wrapper);
-                    return wr->Klass();
-                    break;
-                }
-                case WrapperType::ObjCProtocol: {
-                    ObjCProtocolWrapper* wr = static_cast<ObjCProtocolWrapper*>(wrapper);
-                    return wr->Proto();
-                    break;
-                }
-                default:
-                    // TODO: Unsupported object type
-                    tns::Assert(false, isolate);
-                    break;
-            }
-        } else {
-            Local<Object> obj = arg.As<Object>();
-            DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
-            // CFAutorelease(adapter);
-            return adapter;
-        }
-    }
-
-    // TODO: Handle other possible types
-    tns::Assert(false, isolate);
+  Isolate* isolate = context->GetIsolate();
+  if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
     return nil;
-}
-
-Local<Value> Interop::StructToValue(Local<Context> context, void* result, StructInfo structInfo, std::shared_ptr<Persistent<Value>> parentStruct) {
-    Isolate* isolate = context->GetIsolate();
-    StructWrapper* wrapper = nullptr;
-    if (parentStruct == nullptr) {
-        ffi_type* ffiType = structInfo.FFIType();
-        void* dest = malloc(ffiType->size);
-        memcpy(dest, result, ffiType->size);
-
-        wrapper = new StructWrapper(structInfo, dest, nullptr);
+  } else if (tns::IsString(arg)) {
+    NSString* result = tns::ToNSString(isolate, arg);
+    return result;
+  } else if (tns::IsNumber(arg)) {
+    double value = tns::ToNumber(isolate, arg);
+    return @(value);
+  } else if (arg->IsDate()) {
+    Local<Date> date = arg.As<Date>();
+    double time = date->ValueOf();
+    NSDate* nsDate = [NSDate dateWithTimeIntervalSince1970:(time / 1000)];
+    return nsDate;
+  } else if (tns::IsBool(arg)) {
+    bool value = tns::ToBool(arg);
+    return @(value);
+  } else if (arg->IsArray()) {
+    Local<Object> obj = arg.As<Object>();
+    ArrayAdapter* adapter = [[ArrayAdapter alloc] initWithJSObject:obj isolate:isolate];
+    return adapter;
+  } else if (arg->IsObject()) {
+    if (BaseDataWrapper* wrapper = tns::GetValue(isolate, arg)) {
+      switch (wrapper->Type()) {
+        case WrapperType::ObjCObject: {
+          ObjCDataWrapper* wr = static_cast<ObjCDataWrapper*>(wrapper);
+          return wr->Data();
+          break;
+        }
+        case WrapperType::ObjCClass: {
+          ObjCClassWrapper* wr = static_cast<ObjCClassWrapper*>(wrapper);
+          return wr->Klass();
+          break;
+        }
+        case WrapperType::ObjCProtocol: {
+          ObjCProtocolWrapper* wr = static_cast<ObjCProtocolWrapper*>(wrapper);
+          return wr->Proto();
+          break;
+        }
+        default:
+          // TODO: Unsupported object type
+          tns::Assert(false, isolate);
+          break;
+      }
     } else {
-        Local<Value> parent = parentStruct->Get(isolate);
-        BaseDataWrapper* parentWrapper = tns::GetValue(isolate, parent);
-        if (parentWrapper != nullptr && parentWrapper->Type() == WrapperType::Struct) {
-            StructWrapper* parentStructWrapper = static_cast<StructWrapper*>(parentWrapper);
-            parentStructWrapper->IncrementChildren();
-        }
-        wrapper = new StructWrapper(structInfo, result, parentStruct);
+      Local<Object> obj = arg.As<Object>();
+      DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
+      // CFAutorelease(adapter);
+      return adapter;
     }
+  }
 
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-    std::pair<void*, std::string> key = std::make_pair(wrapper->Data(), structInfo.Name());
-    auto it = cache->StructInstances.find(key);
-    if (it != cache->StructInstances.end()) {
-        return it->second->Get(isolate);
-    }
-
-    Local<Value> res = ArgConverter::ConvertArgument(context, wrapper);
-    if (parentStruct == nullptr) {
-        std::shared_ptr<Persistent<Value>> poResult = ObjectManager::Register(context, res);
-        cache->StructInstances.emplace(key, poResult);
-    }
-    return res;
+  // TODO: Handle other possible types
+  tns::Assert(false, isolate);
+  return nil;
 }
 
-void Interop::InitializeStruct(Local<Context> context, void* destBuffer, std::vector<StructField> fields, Local<Value> inititalizer) {
-    ptrdiff_t position = 0;
-    Interop::InitializeStruct(context, destBuffer, fields, inititalizer, position);
+Local<Value> Interop::StructToValue(Local<Context> context, void* result, StructInfo structInfo,
+                                    std::shared_ptr<Persistent<Value>> parentStruct) {
+  Isolate* isolate = context->GetIsolate();
+  StructWrapper* wrapper = nullptr;
+  if (parentStruct == nullptr) {
+    ffi_type* ffiType = structInfo.FFIType();
+    void* dest = malloc(ffiType->size);
+    memcpy(dest, result, ffiType->size);
+
+    wrapper = new StructWrapper(structInfo, dest, nullptr);
+  } else {
+    Local<Value> parent = parentStruct->Get(isolate);
+    BaseDataWrapper* parentWrapper = tns::GetValue(isolate, parent);
+    if (parentWrapper != nullptr && parentWrapper->Type() == WrapperType::Struct) {
+      StructWrapper* parentStructWrapper = static_cast<StructWrapper*>(parentWrapper);
+      parentStructWrapper->IncrementChildren();
+    }
+    wrapper = new StructWrapper(structInfo, result, parentStruct);
+  }
+
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+  std::pair<void*, std::string> key = std::make_pair(wrapper->Data(), structInfo.Name());
+  auto it = cache->StructInstances.find(key);
+  if (it != cache->StructInstances.end()) {
+    return it->second->Get(isolate);
+  }
+
+  Local<Value> res = ArgConverter::ConvertArgument(context, wrapper);
+  if (parentStruct == nullptr) {
+    std::shared_ptr<Persistent<Value>> poResult = ObjectManager::Register(context, res);
+    cache->StructInstances.emplace(key, poResult);
+  }
+  return res;
 }
 
-void Interop::InitializeStruct(Local<Context> context, void* destBuffer, std::vector<StructField> fields, Local<Value> inititalizer, ptrdiff_t& position) {
-    Isolate* isolate = context->GetIsolate();
-    for (auto it = fields.begin(); it != fields.end(); it++) {
-        StructField field = *it;
+void Interop::InitializeStruct(Local<Context> context, void* destBuffer,
+                               std::vector<StructField> fields, Local<Value> inititalizer) {
+  ptrdiff_t position = 0;
+  Interop::InitializeStruct(context, destBuffer, fields, inititalizer, position);
+}
 
-        Local<Value> value;
-        if (!inititalizer.IsEmpty() && !inititalizer->IsNullOrUndefined() && inititalizer->IsObject()) {
-            bool success = inititalizer.As<Object>()->Get(context, tns::ToV8String(isolate, field.Name())).ToLocal(&value);
-            tns::Assert(success, isolate);
-        }
+void Interop::InitializeStruct(Local<Context> context, void* destBuffer,
+                               std::vector<StructField> fields, Local<Value> inititalizer,
+                               ptrdiff_t& position) {
+  Isolate* isolate = context->GetIsolate();
+  for (auto it = fields.begin(); it != fields.end(); it++) {
+    StructField field = *it;
 
-        BinaryTypeEncodingType type = field.Encoding()->type;
-
-        if (type == BinaryTypeEncodingType::StructDeclarationReference) {
-            const Meta* meta = ArgConverter::GetMeta(field.Encoding()->details.declarationReference.name.valuePtr());
-            tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
-            const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
-            StructInfo nestedStructInfo = FFICall::GetStructInfo(structMeta);
-            Interop::InitializeStruct(context, destBuffer, nestedStructInfo.Fields(), value, position);
-            position += nestedStructInfo.FFIType()->size;
-        } else if (type == BinaryTypeEncodingType::AnonymousStructEncoding) {
-            size_t fieldsCount = field.Encoding()->details.anonymousRecord.fieldsCount;
-            const TypeEncoding* fieldEncoding = field.Encoding()->details.anonymousRecord.getFieldsEncodings();
-            const String* fieldNames = field.Encoding()->details.anonymousRecord.getFieldNames();
-            StructInfo nestedStructInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
-            ptrdiff_t offset = position + field.Offset();
-            uint8_t* dst = (uint8_t*)destBuffer + offset;
-            Interop::InitializeStruct(context, dst, nestedStructInfo.Fields(), value, position);
-            position += nestedStructInfo.FFIType()->size;
-        } else if (type == BinaryTypeEncodingType::ConstantArrayEncoding) {
-            const TypeEncoding* innerType = field.Encoding()->details.constantArray.getInnerType();
-            ffi_type* ffiType = FFICall::GetArgumentType(innerType);
-            uint32_t length = field.Encoding()->details.constantArray.size;
-            ptrdiff_t offset = position + field.Offset();
-
-            if (value.IsEmpty()) {
-                position += length;
-            } else if (value->IsArray()) {
-                Local<v8::Array> array = value.As<v8::Array>();
-                uint32_t min = std::min(length, array->Length());
-                for (uint32_t index = 0; index < min; index++) {
-                    Local<Value> element;
-                    bool success = array->Get(context, index).ToLocal(&element);
-                    tns::Assert(success, isolate);
-                    uint8_t* dst = (uint8_t*)destBuffer + offset;
-                    Interop::WriteValue(context, innerType, dst, element);
-                    offset += ffiType->size;
-                }
-            } else {
-                void* data = Reference::GetWrappedPointer(context, value, field.Encoding());
-                if (data != nullptr) {
-                    uint8_t* dst = (uint8_t*)destBuffer + offset;
-                    memcpy(dst, data, length * ffiType->size);
-                }
-            }
-            FFICall::DisposeFFIType(ffiType, innerType);
-        } else if (type == BinaryTypeEncodingType::FunctionPointerEncoding) {
-            Interop::WriteValue(context, field.Encoding(), destBuffer, value);
-        } else if (type == BinaryTypeEncodingType::PointerEncoding) {
-            const TypeEncoding* innerType = field.Encoding()->details.pointer.getInnerType();
-            Interop::WriteValue(context, innerType, destBuffer, value);
-        } else {
-            ptrdiff_t offset = position + field.Offset();
-
-            if (type == BinaryTypeEncodingType::UCharEncoding) {
-                Interop::SetStructValue<unsigned char>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::UShortEncoding) {
-                Interop::SetStructValue<ushort>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::ShortEncoding) {
-                Interop::SetStructValue<short>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::UIntEncoding) {
-                Interop::SetStructValue<uint>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::IntEncoding) {
-                Interop::SetStructValue<int>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::ULongEncoding) {
-                Interop::SetStructValue<unsigned long>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::LongEncoding) {
-                Interop::SetStructValue<long>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::ULongLongEncoding) {
-                Interop::SetStructValue<unsigned long long>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::LongLongEncoding) {
-                Interop::SetStructValue<long long>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::FloatEncoding) {
-                Interop::SetStructValue<float>(value, destBuffer, offset);
-            } else if (type == BinaryTypeEncodingType::DoubleEncoding) {
-                Interop::SetStructValue<double>(value, destBuffer, offset);
-            } else {
-                // TODO: Unsupported struct field encoding
-                tns::Assert(false, isolate);
-            }
-        }
+    Local<Value> value;
+    if (!inititalizer.IsEmpty() && !inititalizer->IsNullOrUndefined() && inititalizer->IsObject()) {
+      bool success = inititalizer.As<Object>()
+                         ->Get(context, tns::ToV8String(isolate, field.Name()))
+                         .ToLocal(&value);
+      tns::Assert(success, isolate);
     }
+
+    BinaryTypeEncodingType type = field.Encoding()->type;
+
+    if (type == BinaryTypeEncodingType::StructDeclarationReference) {
+      const Meta* meta =
+          ArgConverter::GetMeta(field.Encoding()->details.declarationReference.name.valuePtr());
+      tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
+      const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
+      StructInfo nestedStructInfo = FFICall::GetStructInfo(structMeta);
+      Interop::InitializeStruct(context, destBuffer, nestedStructInfo.Fields(), value, position);
+      position += nestedStructInfo.FFIType()->size;
+    } else if (type == BinaryTypeEncodingType::AnonymousStructEncoding) {
+      size_t fieldsCount = field.Encoding()->details.anonymousRecord.fieldsCount;
+      const TypeEncoding* fieldEncoding =
+          field.Encoding()->details.anonymousRecord.getFieldsEncodings();
+      const String* fieldNames = field.Encoding()->details.anonymousRecord.getFieldNames();
+      StructInfo nestedStructInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
+      ptrdiff_t offset = position + field.Offset();
+      uint8_t* dst = (uint8_t*)destBuffer + offset;
+      Interop::InitializeStruct(context, dst, nestedStructInfo.Fields(), value, position);
+      position += nestedStructInfo.FFIType()->size;
+    } else if (type == BinaryTypeEncodingType::ConstantArrayEncoding) {
+      const TypeEncoding* innerType = field.Encoding()->details.constantArray.getInnerType();
+      ffi_type* ffiType = FFICall::GetArgumentType(innerType);
+      uint32_t length = field.Encoding()->details.constantArray.size;
+      ptrdiff_t offset = position + field.Offset();
+
+      if (value.IsEmpty()) {
+        position += length;
+      } else if (value->IsArray()) {
+        Local<v8::Array> array = value.As<v8::Array>();
+        uint32_t min = std::min(length, array->Length());
+        for (uint32_t index = 0; index < min; index++) {
+          Local<Value> element;
+          bool success = array->Get(context, index).ToLocal(&element);
+          tns::Assert(success, isolate);
+          uint8_t* dst = (uint8_t*)destBuffer + offset;
+          Interop::WriteValue(context, innerType, dst, element);
+          offset += ffiType->size;
+        }
+      } else {
+        void* data = Reference::GetWrappedPointer(context, value, field.Encoding());
+        if (data != nullptr) {
+          uint8_t* dst = (uint8_t*)destBuffer + offset;
+          memcpy(dst, data, length * ffiType->size);
+        }
+      }
+      FFICall::DisposeFFIType(ffiType, innerType);
+    } else if (type == BinaryTypeEncodingType::FunctionPointerEncoding) {
+      Interop::WriteValue(context, field.Encoding(), destBuffer, value);
+    } else if (type == BinaryTypeEncodingType::PointerEncoding) {
+      const TypeEncoding* innerType = field.Encoding()->details.pointer.getInnerType();
+      Interop::WriteValue(context, innerType, destBuffer, value);
+    } else {
+      ptrdiff_t offset = position + field.Offset();
+
+      if (type == BinaryTypeEncodingType::UCharEncoding) {
+        Interop::SetStructValue<unsigned char>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::UShortEncoding) {
+        Interop::SetStructValue<ushort>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::ShortEncoding) {
+        Interop::SetStructValue<short>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::UIntEncoding) {
+        Interop::SetStructValue<uint>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::IntEncoding) {
+        Interop::SetStructValue<int>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::ULongEncoding) {
+        Interop::SetStructValue<unsigned long>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::LongEncoding) {
+        Interop::SetStructValue<long>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::ULongLongEncoding) {
+        Interop::SetStructValue<unsigned long long>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::LongLongEncoding) {
+        Interop::SetStructValue<long long>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::FloatEncoding) {
+        Interop::SetStructValue<float>(value, destBuffer, offset);
+      } else if (type == BinaryTypeEncodingType::DoubleEncoding) {
+        Interop::SetStructValue<double>(value, destBuffer, offset);
+      } else {
+        // TODO: Unsupported struct field encoding
+        tns::Assert(false, isolate);
+      }
+    }
+  }
 }
 
 template <typename T>
 void Interop::SetStructValue(Local<Value> value, void* destBuffer, ptrdiff_t position) {
-    double result = !value.IsEmpty() && !value->IsNullOrUndefined() && value->IsNumber()
-        ? value.As<Number>()->Value() : 0;
-    *static_cast<T*>((void*)((uint8_t*)destBuffer + position)) = result;
+  double result = !value.IsEmpty() && !value->IsNullOrUndefined() && value->IsNumber()
+                      ? value.As<Number>()->Value()
+                      : 0;
+  *static_cast<T*>((void*)((uint8_t*)destBuffer + position)) = result;
 }
 
-Local<Value> Interop::GetResultByType(Local<Context> context, BaseDataWrapper* typeWrapper, BaseCall* call, std::shared_ptr<Persistent<Value>> parentStruct) {
-    Isolate* isolate = context->GetIsolate();
-    
-    if (typeWrapper->Type() == WrapperType::StructType) {
-        StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
-        StructInfo structInfo = structTypeWrapper->StructInfo();
+Local<Value> Interop::GetResultByType(Local<Context> context, BaseDataWrapper* typeWrapper,
+                                      BaseCall* call,
+                                      std::shared_ptr<Persistent<Value>> parentStruct) {
+  Isolate* isolate = context->GetIsolate();
 
-        void* result = call->ResultBuffer();
-        Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
-        return value;
-    }
-    
-    return Null(isolate);
+  if (typeWrapper->Type() == WrapperType::StructType) {
+    StructTypeWrapper* structTypeWrapper = static_cast<StructTypeWrapper*>(typeWrapper);
+    StructInfo structInfo = structTypeWrapper->StructInfo();
+
+    void* result = call->ResultBuffer();
+    Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
+    return value;
+  }
+
+  return Null(isolate);
 }
 
-Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* typeEncoding, BaseCall* call, bool marshalToPrimitive, std::shared_ptr<Persistent<Value>> parentStruct, bool isStructMember, bool ownsReturnedObject, bool returnsUnmanaged, bool isInitializer) {
-    Isolate* isolate = context->GetIsolate();
+Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* typeEncoding,
+                                BaseCall* call, bool marshalToPrimitive,
+                                std::shared_ptr<Persistent<Value>> parentStruct,
+                                bool isStructMember, bool ownsReturnedObject, bool returnsUnmanaged,
+                                bool isInitializer) {
+  Isolate* isolate = context->GetIsolate();
 
-    if (returnsUnmanaged) {
-        uint8_t* data = call->GetResult<uint8_t*>();
-        UnmanagedTypeWrapper* wrapper = new UnmanagedTypeWrapper(data, typeEncoding);
-        Local<Value> result = UnmanagedType::Create(context, wrapper);
-        ObjectManager::Register(context, result);
-        return result;
+  if (returnsUnmanaged) {
+    uint8_t* data = call->GetResult<uint8_t*>();
+    UnmanagedTypeWrapper* wrapper = new UnmanagedTypeWrapper(data, typeEncoding);
+    Local<Value> result = UnmanagedType::Create(context, wrapper);
+    ObjectManager::Register(context, result);
+    return result;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::ExtVectorEncoding) {
+    ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding, isStructMember);
+    const TypeEncoding* innerTypeEncoding = typeEncoding->details.extVector.getInnerType();
+    void* buffer = call->ResultBuffer();
+    void* data = malloc(ffiType->size);
+    memcpy(data, buffer, ffiType->size);
+    Local<Value> value =
+        ExtVector::NewInstance(isolate, data, ffiType, innerTypeEncoding, typeEncoding);
+    ObjectManager::Register(context, value);
+    return value;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
+    const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
+    const Meta* meta = ArgConverter::GetMeta(structName);
+    tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
+
+    void* result = call->ResultBuffer();
+
+    const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
+    StructInfo structInfo = FFICall::GetStructInfo(structMeta, structName);
+    Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
+    return value;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::AnonymousStructEncoding) {
+    size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
+    const TypeEncoding* fieldEncoding = typeEncoding->details.anonymousRecord.getFieldsEncodings();
+    const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
+    StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
+    void* result = call->ResultBuffer();
+    Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
+    return value;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::ConstantArrayEncoding) {
+    const TypeEncoding* innerType = typeEncoding->details.constantArray.getInnerType();
+    ffi_type* innerFFIType = FFICall::GetArgumentType(innerType, isStructMember);
+    int length = typeEncoding->details.constantArray.size;
+    Local<v8::Array> array = v8::Array::New(isolate, length);
+
+    for (int i = 0; i < length; i++) {
+      size_t offset = i * innerFFIType->size;
+      BaseCall bc((uint8_t*)call->ResultBuffer(), offset);
+      Local<Value> element = Interop::GetResult(context, innerType, &bc, false);
+      bool success = array->Set(context, i, element).FromMaybe(false);
+      tns::Assert(success, isolate);
+    }
+    FFICall::DisposeFFIType(innerFFIType, innerType);
+    return array;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding) {
+    SEL result = call->GetResult<SEL>();
+    if (result == nil) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::ExtVectorEncoding) {
-        ffi_type* ffiType = FFICall::GetArgumentType(typeEncoding, isStructMember);
-        const TypeEncoding* innerTypeEncoding = typeEncoding->details.extVector.getInnerType();
-        void* buffer = call->ResultBuffer();
-        void* data = malloc(ffiType->size);
-        memcpy(data, buffer, ffiType->size);
-        Local<Value> value = ExtVector::NewInstance(isolate, data, ffiType, innerTypeEncoding, typeEncoding);
-        ObjectManager::Register(context, value);
-        return value;
+    NSString* selStr = NSStringFromSelector(result);
+    return tns::ToV8String(isolate, [selStr UTF8String]);
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding) {
+    id result = call->GetResult<id>();
+    if (result == nil) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::StructDeclarationReference) {
-        const char* structName = typeEncoding->details.declarationReference.name.valuePtr();
-        const Meta* meta = ArgConverter::GetMeta(structName);
-        tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
-
-        void* result = call->ResultBuffer();
-
-        const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
-        StructInfo structInfo = FFICall::GetStructInfo(structMeta, structName);
-        Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
-        return value;
+    Protocol* protocol = static_cast<Protocol*>(result);
+    const ProtocolMeta* protocolMeta = ArgConverter::FindProtocolMeta(protocol);
+    if (protocolMeta == nullptr) {
+      // Unable to find protocol metadata
+      tns::Assert(false, isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::AnonymousStructEncoding) {
-        size_t fieldsCount = typeEncoding->details.anonymousRecord.fieldsCount;
-        const TypeEncoding* fieldEncoding = typeEncoding->details.anonymousRecord.getFieldsEncodings();
-        const String* fieldNames = typeEncoding->details.anonymousRecord.getFieldNames();
-        StructInfo structInfo = FFICall::GetStructInfo(fieldsCount, fieldEncoding, fieldNames);
-        void* result = call->ResultBuffer();
-        Local<Value> value = Interop::StructToValue(context, result, structInfo, parentStruct);
-        return value;
+    auto cache = Caches::Get(isolate);
+    KnownUnknownClassPair pair;
+    std::vector<std::string> emptyProtocols;
+    cache->ObjectCtorInitializer(context, protocolMeta, pair, emptyProtocols);
+
+    auto it = cache->ProtocolCtorFuncs.find(protocolMeta->name());
+    if (it != cache->ProtocolCtorFuncs.end()) {
+      return it->second->Get(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::ConstantArrayEncoding) {
-        const TypeEncoding* innerType = typeEncoding->details.constantArray.getInnerType();
-        ffi_type* innerFFIType = FFICall::GetArgumentType(innerType, isStructMember);
-        int length = typeEncoding->details.constantArray.size;
-        Local<v8::Array> array = v8::Array::New(isolate, length);
+    tns::Assert(false, isolate);
+  }
 
-        for (int i = 0; i < length; i++) {
-            size_t offset = i * innerFFIType->size;
-            BaseCall bc((uint8_t*)call->ResultBuffer(), offset);
-            Local<Value> element = Interop::GetResult(context, innerType, &bc, false);
-            bool success = array->Set(context, i, element).FromMaybe(false);
-            tns::Assert(success, isolate);
-        }
-        FFICall::DisposeFFIType(innerFFIType, innerType);
-        return array;
+  if (typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
+    Class result = call->GetResult<Class>();
+    if (result == nil) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding) {
-        SEL result = call->GetResult<SEL>();
-        if (result == nil) {
-            return Null(isolate);
-        }
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
+    while (true) {
+      const char* name = class_getName(result);
 
-        NSString* selStr = NSStringFromSelector(result);
-        return tns::ToV8String(isolate, [selStr UTF8String]);
-    }
-
-    if (typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding) {
-        id result = call->GetResult<id>();
-        if (result == nil) {
-            return Null(isolate);
-        }
-
-        Protocol* protocol = static_cast<Protocol*>(result);
-        const ProtocolMeta* protocolMeta = ArgConverter::FindProtocolMeta(protocol);
-        if (protocolMeta == nullptr) {
-            // Unable to find protocol metadata
-            tns::Assert(false, isolate);
-        }
-
-        auto cache = Caches::Get(isolate);
-        KnownUnknownClassPair pair;
+      const Meta* meta = ArgConverter::GetMeta(name);
+      if (meta != nullptr &&
+          (meta->type() == MetaType::Interface || meta->type() == MetaType::ProtocolType)) {
+        const BaseClassMeta* baseMeta = static_cast<const BaseClassMeta*>(meta);
+        Class knownClass = meta->type() == MetaType::Interface ? objc_getClass(meta->name()) : nil;
+        KnownUnknownClassPair pair(knownClass);
         std::vector<std::string> emptyProtocols;
-        cache->ObjectCtorInitializer(context, protocolMeta, pair, emptyProtocols);
+        cache->ObjectCtorInitializer(context, baseMeta, pair, emptyProtocols);
+      }
 
-        auto it = cache->ProtocolCtorFuncs.find(protocolMeta->name());
-        if (it != cache->ProtocolCtorFuncs.end()) {
-            return it->second->Get(isolate);
-        }
+      auto it = cache->CtorFuncs.find(name);
+      if (it != cache->CtorFuncs.end()) {
+        return it->second->Get(isolate);
+      }
 
-        tns::Assert(false, isolate);
+      result = class_getSuperclass(result);
+      if (!result) {
+        break;
+      }
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
-        Class result = call->GetResult<Class>();
-        if (result == nil) {
-            return Null(isolate);
-        }
+    tns::Assert(false, isolate);
+  }
 
-        std::shared_ptr<Caches> cache = Caches::Get(isolate);
-        while (true) {
-            const char* name = class_getName(result);
+  if (typeEncoding->type == BinaryTypeEncodingType::BlockEncoding) {
+    JSBlock* block = call->GetResult<JSBlock*>();
 
-            const Meta* meta = ArgConverter::GetMeta(name);
-            if (meta != nullptr && (meta->type() == MetaType::Interface || meta->type() == MetaType::ProtocolType)) {
-                const BaseClassMeta* baseMeta = static_cast<const BaseClassMeta*>(meta);
-                Class knownClass = meta->type() == MetaType::Interface ? objc_getClass(meta->name()) : nil;
-                KnownUnknownClassPair pair(knownClass);
-                std::vector<std::string> emptyProtocols;
-                cache->ObjectCtorInitializer(context, baseMeta, pair, emptyProtocols);
-            }
-
-            auto it = cache->CtorFuncs.find(name);
-            if (it != cache->CtorFuncs.end()) {
-                return it->second->Get(isolate);
-            }
-
-            result = class_getSuperclass(result);
-            if (!result) {
-                break;
-            }
-        }
-
-        tns::Assert(false, isolate);
+    if (block == nullptr) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::BlockEncoding) {
-        JSBlock* block = call->GetResult<JSBlock*>();
-
-        if (block == nullptr) {
-            return Null(isolate);
-        }
-
-        if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
-            MethodCallbackWrapper* wrapper = static_cast<MethodCallbackWrapper*>(block->userData);
-            Local<v8::Function> callback = wrapper->callback_->Get(isolate).As<v8::Function>();
-            return callback;
-        }
-
-        BlockWrapper* blockWrapper = new BlockWrapper(block, typeEncoding, true);
-        Local<External> ext = External::New(isolate, blockWrapper);
-        Local<v8::Function> callback;
-
-        CFRetain(block);
-
-        bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-            Local<External> ext = info.Data().As<External>();
-            BlockWrapper* wrapper = static_cast<BlockWrapper*>(ext->Value());
-
-            JSBlock* block = static_cast<JSBlock*>(wrapper->Block());
-
-            const TypeEncoding* typeEncoding = wrapper->Encodings();
-            int argsCount = typeEncoding->details.block.signature.count;
-            const TypeEncoding* enc = typeEncoding->details.block.signature.first();
-
-            ParametrizedCall* parametrizedCall = ParametrizedCall::Get(enc, 1, argsCount);
-            FFICall call(parametrizedCall);
-
-            V8FunctionCallbackArgs args(info);
-            Isolate* isolate = info.GetIsolate();
-            Local<Context> context = isolate->GetCurrentContext();
-            Interop::SetValue(call.ArgumentBuffer(0), block);
-            Interop::SetFFIParams(context, enc, &call, argsCount, 1, args);
-
-            ffi_call(parametrizedCall->Cif, FFI_FN(block->invoke), call.ResultBuffer(), call.ArgsArray());
-
-            Local<Value> result = Interop::GetResult(context, enc, &call, true, nullptr);
-
-            info.GetReturnValue().Set(result);
-        }, ext).ToLocal(&callback);
-        tns::Assert(success, isolate);
-
-        tns::SetValue(isolate, callback, blockWrapper);
-        ObjectManager::Register(context, callback);
-
-        return callback;
+    if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
+      MethodCallbackWrapper* wrapper = static_cast<MethodCallbackWrapper*>(block->userData);
+      Local<v8::Function> callback = wrapper->callback_->Get(isolate).As<v8::Function>();
+      return callback;
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::FunctionPointerEncoding) {
-        uint8_t* functionPointer = call->GetResult<uint8_t*>();
-        if (functionPointer == nullptr) {
-            return Null(isolate);
-        }
+    BlockWrapper* blockWrapper = new BlockWrapper(block, typeEncoding, true);
+    Local<External> ext = External::New(isolate, blockWrapper);
+    Local<v8::Function> callback;
 
-        const TypeEncoding* parametersEncoding = typeEncoding->details.functionPointer.signature.first();
-        size_t parametersCount = typeEncoding->details.functionPointer.signature.count;
-        AnonymousFunctionWrapper* wrapper = new AnonymousFunctionWrapper(functionPointer, parametersEncoding, parametersCount);
-        Local<External> ext = External::New(isolate, wrapper);
+    CFRetain(block);
 
-        Local<v8::Function> func;
-        bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-            Isolate* isolate = info.GetIsolate();
-            AnonymousFunctionWrapper* wrapper = static_cast<AnonymousFunctionWrapper*>(info.Data().As<External>()->Value());
-            tns::Assert(wrapper != nullptr, isolate);
+    bool success =
+        v8::Function::New(
+            context,
+            [](const FunctionCallbackInfo<Value>& info) {
+              Local<External> ext = info.Data().As<External>();
+              BlockWrapper* wrapper = static_cast<BlockWrapper*>(ext->Value());
 
-            V8FunctionCallbackArgs args(info);
-            void* functionPointer = wrapper->Data();
-            const TypeEncoding* typeEncoding = wrapper->ParametersEncoding();
+              JSBlock* block = static_cast<JSBlock*>(wrapper->Block());
 
-            Local<Context> context = isolate->GetCurrentContext();
-            CMethodCall methodCall(context, functionPointer, typeEncoding, args, false, false);
-            Local<Value> result = Interop::CallFunction(methodCall);
+              const TypeEncoding* typeEncoding = wrapper->Encodings();
+              int argsCount = typeEncoding->details.block.signature.count;
+              const TypeEncoding* enc = typeEncoding->details.block.signature.first();
 
-            info.GetReturnValue().Set(result);
-        }, ext).ToLocal(&func);
-        tns::Assert(success, isolate);
+              ParametrizedCall* parametrizedCall = ParametrizedCall::Get(enc, 1, argsCount);
+              FFICall call(parametrizedCall);
 
-        tns::SetValue(isolate, func, wrapper);
-        ObjectManager::Register(context, func);
+              V8FunctionCallbackArgs args(info);
+              Isolate* isolate = info.GetIsolate();
+              Local<Context> context = isolate->GetCurrentContext();
+              Interop::SetValue(call.ArgumentBuffer(0), block);
+              Interop::SetFFIParams(context, enc, &call, argsCount, 1, args);
 
-        return func;
+              ffi_call(parametrizedCall->Cif, FFI_FN(block->invoke), call.ResultBuffer(),
+                       call.ArgsArray());
+
+              Local<Value> result = Interop::GetResult(context, enc, &call, true, nullptr);
+
+              info.GetReturnValue().Set(result);
+            },
+            ext)
+            .ToLocal(&callback);
+    tns::Assert(success, isolate);
+
+    tns::SetValue(isolate, callback, blockWrapper);
+    ObjectManager::Register(context, callback);
+
+    return callback;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::FunctionPointerEncoding) {
+    uint8_t* functionPointer = call->GetResult<uint8_t*>();
+    if (functionPointer == nullptr) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::PointerEncoding) {
-        uint8_t* result = call->GetResult<uint8_t*>();
-        if (result == nullptr) {
-            return Null(isolate);
-        }
+    const TypeEncoding* parametersEncoding =
+        typeEncoding->details.functionPointer.signature.first();
+    size_t parametersCount = typeEncoding->details.functionPointer.signature.count;
+    AnonymousFunctionWrapper* wrapper =
+        new AnonymousFunctionWrapper(functionPointer, parametersEncoding, parametersCount);
+    Local<External> ext = External::New(isolate, wrapper);
 
-        const TypeEncoding* innerType = typeEncoding->details.pointer.getInnerType();
-        Local<Value> pointer = Pointer::NewInstance(context, result);
+    Local<v8::Function> func;
+    bool success =
+        v8::Function::New(
+            context,
+            [](const FunctionCallbackInfo<Value>& info) {
+              Isolate* isolate = info.GetIsolate();
+              AnonymousFunctionWrapper* wrapper =
+                  static_cast<AnonymousFunctionWrapper*>(info.Data().As<External>()->Value());
+              tns::Assert(wrapper != nullptr, isolate);
 
-        if (innerType->type == BinaryTypeEncodingType::VoidEncoding) {
-            return pointer;
-        }
+              V8FunctionCallbackArgs args(info);
+              void* functionPointer = wrapper->Data();
+              const TypeEncoding* typeEncoding = wrapper->ParametersEncoding();
 
-        Local<Value> type = Interop::GetInteropType(context, innerType->type);
+              Local<Context> context = isolate->GetCurrentContext();
+              CMethodCall methodCall(context, functionPointer, typeEncoding, args, false, false);
+              Local<Value> result = Interop::CallFunction(methodCall);
 
-        std::vector<Local<Value>> args;
-        args.push_back(pointer);
-        if (!type.IsEmpty()) {
-            args.insert(args.begin(), type);
-        }
+              info.GetReturnValue().Set(result);
+            },
+            ext)
+            .ToLocal(&func);
+    tns::Assert(success, isolate);
 
-        Local<Object> instance;
-        Local<v8::Function> interopReferenceCtorFunc = Reference::GetInteropReferenceCtorFunc(context);
-        bool success = interopReferenceCtorFunc->NewInstance(context, (int)args.size(), args.data()).ToLocal(&instance);
-        tns::Assert(success, isolate);
+    tns::SetValue(isolate, func, wrapper);
+    ObjectManager::Register(context, func);
 
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, instance);
-        if (wrapper != nullptr && wrapper->Type() == WrapperType::Reference) {
-            ReferenceWrapper* refWrapper = static_cast<ReferenceWrapper*>(wrapper);
-            refWrapper->SetData(result);
-            refWrapper->SetEncoding(innerType);
-        }
+    return func;
+  }
 
-        return instance;
+  if (typeEncoding->type == BinaryTypeEncodingType::PointerEncoding) {
+    uint8_t* result = call->GetResult<uint8_t*>();
+    if (result == nullptr) {
+      return Null(isolate);
     }
 
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
-        typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
-        typeEncoding->type == BinaryTypeEncodingType::InstanceTypeEncoding) {
+    const TypeEncoding* innerType = typeEncoding->details.pointer.getInnerType();
+    Local<Value> pointer = Pointer::NewInstance(context, result);
 
-        id result = call->GetResult<id>();
-
-        if (result == nil) {
-            return Null(isolate);
-        }
-
-        if (marshalToPrimitive && result == [NSNull null]) {
-            return Null(isolate);
-        }
-
-        if ([result isKindOfClass:[@YES class]]) {
-            return v8::Boolean::New(isolate, [result boolValue]);
-        }
-
-        if (marshalToPrimitive && [result isKindOfClass:[NSDate class]]) {
-            double time = [result timeIntervalSince1970] * 1000.0;
-            Local<Value> date;
-            if (Date::New(context, time).ToLocal(&date)) {
-                return date;
-            }
-
-            std::ostringstream errorStream;
-            errorStream << "Unable to convert " << [result description] << " to a Date object";
-            std::string errorMessage = errorStream.str();
-            Local<Value> error = Exception::Error(tns::ToV8String(isolate, errorMessage));
-            isolate->ThrowException(error);
-            return Local<Value>();
-        }
-
-        if (marshalToPrimitive && [result isKindOfClass:[NSString class]]) {
-            if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-                const char* returnClassName = typeEncoding->details.declarationReference.name.valuePtr();
-                Class returnClass = objc_getClass(returnClassName);
-                if (returnClass != nil && returnClass == [NSMutableString class]) {
-                    marshalToPrimitive = false;
-                }
-            }
-
-            if (marshalToPrimitive) {
-                // Convert NSString instances to javascript strings for all instance method calls
-                return tns::ToV8String(isolate, result);
-            }
-        }
-
-        if (marshalToPrimitive && [result isKindOfClass:[NSNumber class]] && ![result isKindOfClass:[NSDecimalNumber class]]) {
-            // Convert NSNumber instances to javascript numbers for all instance method calls
-            double value = [result doubleValue];
-            return Number::New(isolate, value);
-        }
-
-        auto cache = Caches::Get(isolate);
-        auto it = cache->Instances.find(result);
-        if (it != cache->Instances.end()) {
-            return it->second->Get(isolate);
-        }
-
-        // For NSProxy we will try to read the metadata from typeEncoding->details.interfaceDeclarationReference.name
-        // because class_getSuperclass will directly return NSProxy and thus missing to attach all instance members
-        const TypeEncoding* te = [result isProxy] ? typeEncoding : nullptr;
-
-        ObjCDataWrapper* wrapper = new ObjCDataWrapper(result, te);
-        std::vector<std::string> additionalProtocols = Interop::GetAdditionalProtocols(typeEncoding);
-        Local<Value> jsResult = ArgConverter::ConvertArgument(context, wrapper, false, additionalProtocols);
-
-        if (ownsReturnedObject || isInitializer) {
-            [result release];
-        }
-
-        if ([result isKindOfClass:[NSArray class]]) {
-            // attach Symbol.iterator to the instance
-            SymbolIterator::Set(context, jsResult);
-        }
-        
-        tns::DeleteWrapperIfUnused(isolate, jsResult, wrapper);
-
-        return jsResult;
+    if (innerType->type == BinaryTypeEncodingType::VoidEncoding) {
+      return pointer;
     }
 
-    return Interop::GetPrimitiveReturnType(context, typeEncoding->type, call);
+    Local<Value> type = Interop::GetInteropType(context, innerType->type);
+
+    std::vector<Local<Value>> args;
+    args.push_back(pointer);
+    if (!type.IsEmpty()) {
+      args.insert(args.begin(), type);
+    }
+
+    Local<Object> instance;
+    Local<v8::Function> interopReferenceCtorFunc = Reference::GetInteropReferenceCtorFunc(context);
+    bool success = interopReferenceCtorFunc->NewInstance(context, (int)args.size(), args.data())
+                       .ToLocal(&instance);
+    tns::Assert(success, isolate);
+
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, instance);
+    if (wrapper != nullptr && wrapper->Type() == WrapperType::Reference) {
+      ReferenceWrapper* refWrapper = static_cast<ReferenceWrapper*>(wrapper);
+      refWrapper->SetData(result);
+      refWrapper->SetEncoding(innerType);
+    }
+
+    return instance;
+  }
+
+  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+      typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
+      typeEncoding->type == BinaryTypeEncodingType::InstanceTypeEncoding) {
+    id result = call->GetResult<id>();
+
+    if (result == nil) {
+      return Null(isolate);
+    }
+
+    if (marshalToPrimitive && result == [NSNull null]) {
+      return Null(isolate);
+    }
+
+    if ([result isKindOfClass:[@YES class]]) {
+      return v8::Boolean::New(isolate, [result boolValue]);
+    }
+
+    if (marshalToPrimitive && [result isKindOfClass:[NSDate class]]) {
+      double time = [result timeIntervalSince1970] * 1000.0;
+      Local<Value> date;
+      if (Date::New(context, time).ToLocal(&date)) {
+        return date;
+      }
+
+      std::ostringstream errorStream;
+      errorStream << "Unable to convert " << [result description] << " to a Date object";
+      std::string errorMessage = errorStream.str();
+      Local<Value> error = Exception::Error(tns::ToV8String(isolate, errorMessage));
+      isolate->ThrowException(error);
+      return Local<Value>();
+    }
+
+    if (marshalToPrimitive && [result isKindOfClass:[NSString class]]) {
+      if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+        const char* returnClassName = typeEncoding->details.declarationReference.name.valuePtr();
+        Class returnClass = objc_getClass(returnClassName);
+        if (returnClass != nil && returnClass == [NSMutableString class]) {
+          marshalToPrimitive = false;
+        }
+      }
+
+      if (marshalToPrimitive) {
+        // Convert NSString instances to javascript strings for all instance method calls
+        return tns::ToV8String(isolate, result);
+      }
+    }
+
+    if (marshalToPrimitive && [result isKindOfClass:[NSNumber class]] &&
+        ![result isKindOfClass:[NSDecimalNumber class]]) {
+      // Convert NSNumber instances to javascript numbers for all instance method calls
+      double value = [result doubleValue];
+      return Number::New(isolate, value);
+    }
+
+    auto cache = Caches::Get(isolate);
+    auto it = cache->Instances.find(result);
+    if (it != cache->Instances.end()) {
+      return it->second->Get(isolate);
+    }
+
+    // For NSProxy we will try to read the metadata from
+    // typeEncoding->details.interfaceDeclarationReference.name because class_getSuperclass will
+    // directly return NSProxy and thus missing to attach all instance members
+    const TypeEncoding* te = [result isProxy] ? typeEncoding : nullptr;
+
+    ObjCDataWrapper* wrapper = new ObjCDataWrapper(result, te);
+    std::vector<std::string> additionalProtocols = Interop::GetAdditionalProtocols(typeEncoding);
+    Local<Value> jsResult =
+        ArgConverter::ConvertArgument(context, wrapper, false, additionalProtocols);
+
+    if (ownsReturnedObject || isInitializer) {
+      [result release];
+    }
+
+    if ([result isKindOfClass:[NSArray class]]) {
+      // attach Symbol.iterator to the instance
+      SymbolIterator::Set(context, jsResult);
+    }
+
+    tns::DeleteWrapperIfUnused(isolate, jsResult, wrapper);
+
+    return jsResult;
+  }
+
+  return Interop::GetPrimitiveReturnType(context, typeEncoding->type, call);
 }
 
-Local<Value> Interop::GetPrimitiveReturnType(Local<Context> context, BinaryTypeEncodingType type, BaseCall* call) {
-    Isolate* isolate = context->GetIsolate();
-    if (type == BinaryTypeEncodingType::CStringEncoding) {
-        unsigned char* result = call->GetResult<unsigned char*>();
-        if (result == nullptr) {
-            return Null(isolate);
-        }
-
-        Local<Value> uint8Type = Interop::GetInteropType(context, BinaryTypeEncodingType::UCharEncoding);
-        Local<Value> reference = Reference::FromPointer(context, uint8Type, result);
-        return reference;
+Local<Value> Interop::GetPrimitiveReturnType(Local<Context> context, BinaryTypeEncodingType type,
+                                             BaseCall* call) {
+  Isolate* isolate = context->GetIsolate();
+  if (type == BinaryTypeEncodingType::CStringEncoding) {
+    unsigned char* result = call->GetResult<unsigned char*>();
+    if (result == nullptr) {
+      return Null(isolate);
     }
 
-    if (type == BinaryTypeEncodingType::BoolEncoding) {
-        bool result = call->GetResult<bool>();
-        return v8::Boolean::New(isolate, result);
+    Local<Value> uint8Type =
+        Interop::GetInteropType(context, BinaryTypeEncodingType::UCharEncoding);
+    Local<Value> reference = Reference::FromPointer(context, uint8Type, result);
+    return reference;
+  }
+
+  if (type == BinaryTypeEncodingType::BoolEncoding) {
+    bool result = call->GetResult<bool>();
+    return v8::Boolean::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::UShortEncoding) {
+    unsigned short result = call->GetResult<unsigned short>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::ShortEncoding) {
+    short result = call->GetResult<short>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::UIntEncoding) {
+    unsigned int result = call->GetResult<unsigned int>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::IntEncoding) {
+    int result = call->GetResult<int>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::ULongEncoding) {
+    unsigned long result = call->GetResult<unsigned long>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::LongEncoding) {
+    long result = call->GetResult<long>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::ULongLongEncoding) {
+    unsigned long long result = call->GetResult<unsigned long long>();
+    if (result > kMaxSafeInteger) {
+      return BigInt::NewFromUnsigned(isolate, result);
     }
 
-    if (type == BinaryTypeEncodingType::UShortEncoding) {
-        unsigned short result = call->GetResult<unsigned short>();
-        return Number::New(isolate, result);
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::LongLongEncoding) {
+    long long result = call->GetResult<long long>();
+    if (result < kMinSafeInteger || result > kMaxSafeInteger) {
+      return BigInt::New(isolate, result);
     }
 
-    if (type == BinaryTypeEncodingType::ShortEncoding) {
-        short result = call->GetResult<short>();
-        return Number::New(isolate, result);
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::FloatEncoding) {
+    float result = call->GetResult<float>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::DoubleEncoding) {
+    double result = call->GetResult<double>();
+    return Number::New(isolate, result);
+  }
+
+  if (type == BinaryTypeEncodingType::UnicharEncoding) {
+    unichar result = call->GetResult<unichar>();
+    char chars[2];
+
+    if (result > 127) {
+      chars[0] = (result >> 8) & (1 << 8) - 1;
+      chars[1] = result & (1 << 8) - 1;
+    } else {
+      chars[0] = result;
+      chars[1] = 0;
     }
 
-    if (type == BinaryTypeEncodingType::UIntEncoding) {
-        unsigned int result = call->GetResult<unsigned int>();
-        return Number::New(isolate, result);
-    }
+    return tns::ToV8String(isolate, chars);
+  }
 
-    if (type == BinaryTypeEncodingType::IntEncoding) {
-        int result = call->GetResult<int>();
-        return Number::New(isolate, result);
-    }
+  if (type == BinaryTypeEncodingType::UCharEncoding) {
+    unsigned char result = call->GetResult<unsigned char>();
+    return Number::New(isolate, result);
+  }
 
-    if (type == BinaryTypeEncodingType::ULongEncoding) {
-        unsigned long result = call->GetResult<unsigned long>();
-        return Number::New(isolate, result);
-    }
+  if (type == BinaryTypeEncodingType::CharEncoding) {
+    char result = call->GetResult<char>();
+    return Number::New(isolate, result);
+  }
 
-    if (type == BinaryTypeEncodingType::LongEncoding) {
-        long result = call->GetResult<long>();
-        return Number::New(isolate, result);
-    }
+  if (type != BinaryTypeEncodingType::VoidEncoding) {
+    tns::Assert(false, isolate);
+  }
 
-    if (type == BinaryTypeEncodingType::ULongLongEncoding) {
-        unsigned long long result = call->GetResult<unsigned long long>();
-        if (result > kMaxSafeInteger) {
-            return BigInt::NewFromUnsigned(isolate, result);
-        }
+  // TODO: Handle all the possible return types https://nshipster.com/type-encodings/
 
-        return Number::New(isolate, result);
-    }
-
-    if (type == BinaryTypeEncodingType::LongLongEncoding) {
-        long long result = call->GetResult<long long>();
-        if (result < kMinSafeInteger || result > kMaxSafeInteger) {
-            return BigInt::New(isolate, result);
-        }
-
-        return Number::New(isolate, result);
-    }
-
-    if (type == BinaryTypeEncodingType::FloatEncoding) {
-        float result = call->GetResult<float>();
-        return Number::New(isolate, result);
-    }
-
-    if (type == BinaryTypeEncodingType::DoubleEncoding) {
-        double result = call->GetResult<double>();
-        return Number::New(isolate, result);
-    }
-
-    if (type == BinaryTypeEncodingType::UnicharEncoding) {
-        unichar result = call->GetResult<unichar>();
-        char chars[2];
-
-        if (result > 127) {
-            chars[0] = (result >> 8) & (1 << 8) - 1;
-            chars[1] = result & (1 << 8) - 1;
-        } else {
-            chars[0] = result;
-            chars[1] = 0;
-        }
-
-        return tns::ToV8String(isolate, chars);
-    }
-
-    if (type == BinaryTypeEncodingType::UCharEncoding) {
-        unsigned char result = call->GetResult<unsigned char>();
-        return Number::New(isolate, result);
-    }
-
-    if (type == BinaryTypeEncodingType::CharEncoding) {
-        char result = call->GetResult<char>();
-        return Number::New(isolate, result);
-    }
-
-    if (type != BinaryTypeEncodingType::VoidEncoding) {
-        tns::Assert(false, isolate);
-    }
-
-    // TODO: Handle all the possible return types https://nshipster.com/type-encodings/
-
-    return Local<Value>();
+  return Local<Value>();
 }
 
 std::vector<std::string> Interop::GetAdditionalProtocols(const TypeEncoding* typeEncoding) {
-    std::vector<std::string> additionalProtocols;
+  std::vector<std::string> additionalProtocols;
 
-    if (typeEncoding->type == BinaryTypeEncodingType::IdEncoding && typeEncoding->details.idDetails._protocols.offset > 0) {
-        PtrTo<Array<String>> protocols = typeEncoding->details.idDetails._protocols;
-        for (auto it = protocols->begin(); it != protocols->end(); it++) {
-            const char* protocolName = (*it).valuePtr();
-            additionalProtocols.push_back(protocolName);
-        }
-    } else if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference && typeEncoding->details.interfaceDeclarationReference._protocols.offset > 0) {
-        PtrTo<Array<String>> protocols = typeEncoding->details.interfaceDeclarationReference._protocols;
-        for (auto it = protocols->begin(); it != protocols->end(); it++) {
-            const char* protocolName = (*it).valuePtr();
-            additionalProtocols.push_back(protocolName);
-        }
+  if (typeEncoding->type == BinaryTypeEncodingType::IdEncoding &&
+      typeEncoding->details.idDetails._protocols.offset > 0) {
+    PtrTo<Array<String>> protocols = typeEncoding->details.idDetails._protocols;
+    for (auto it = protocols->begin(); it != protocols->end(); it++) {
+      const char* protocolName = (*it).valuePtr();
+      additionalProtocols.push_back(protocolName);
     }
+  } else if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference &&
+             typeEncoding->details.interfaceDeclarationReference._protocols.offset > 0) {
+    PtrTo<Array<String>> protocols = typeEncoding->details.interfaceDeclarationReference._protocols;
+    for (auto it = protocols->begin(); it != protocols->end(); it++) {
+      const char* protocolName = (*it).valuePtr();
+      additionalProtocols.push_back(protocolName);
+    }
+  }
 
-    return additionalProtocols;
+  return additionalProtocols;
 }
 
 bool Interop::IsNumbericType(BinaryTypeEncodingType type) {
-    return
-        type == BinaryTypeEncodingType::UCharEncoding ||
-        type == BinaryTypeEncodingType::CharEncoding ||
-        type == BinaryTypeEncodingType::UShortEncoding ||
-        type == BinaryTypeEncodingType::ShortEncoding ||
-        type == BinaryTypeEncodingType::UIntEncoding ||
-        type == BinaryTypeEncodingType::IntEncoding ||
-        type == BinaryTypeEncodingType::ULongEncoding ||
-        type == BinaryTypeEncodingType::LongEncoding ||
-        type == BinaryTypeEncodingType::ULongLongEncoding ||
-        type == BinaryTypeEncodingType::LongLongEncoding ||
-        type == BinaryTypeEncodingType::FloatEncoding ||
-        type == BinaryTypeEncodingType::DoubleEncoding;
+  return type == BinaryTypeEncodingType::UCharEncoding ||
+         type == BinaryTypeEncodingType::CharEncoding ||
+         type == BinaryTypeEncodingType::UShortEncoding ||
+         type == BinaryTypeEncodingType::ShortEncoding ||
+         type == BinaryTypeEncodingType::UIntEncoding ||
+         type == BinaryTypeEncodingType::IntEncoding ||
+         type == BinaryTypeEncodingType::ULongEncoding ||
+         type == BinaryTypeEncodingType::LongEncoding ||
+         type == BinaryTypeEncodingType::ULongLongEncoding ||
+         type == BinaryTypeEncodingType::LongLongEncoding ||
+         type == BinaryTypeEncodingType::FloatEncoding ||
+         type == BinaryTypeEncodingType::DoubleEncoding;
 }
 
-void Interop::SetStructPropertyValue(Local<Context> context, StructWrapper* wrapper, StructField field, Local<Value> value) {
-    if (value.IsEmpty()) {
-        return;
+void Interop::SetStructPropertyValue(Local<Context> context, StructWrapper* wrapper,
+                                     StructField field, Local<Value> value) {
+  if (value.IsEmpty()) {
+    return;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+  uint8_t* data = (uint8_t*)wrapper->Data();
+  uint8_t* destBuffer = data + field.Offset();
+
+  const TypeEncoding* fieldEncoding = field.Encoding();
+  switch (fieldEncoding->type) {
+    case BinaryTypeEncodingType::StructDeclarationReference: {
+      Local<Object> obj = value.As<Object>();
+      Local<External> ext = obj->GetInternalField(0).As<External>();
+      StructWrapper* targetStruct = static_cast<StructWrapper*>(ext->Value());
+
+      void* sourceBuffer = targetStruct->Data();
+      size_t fieldSize = field.FFIType()->size;
+      memcpy(destBuffer, sourceBuffer, fieldSize);
+      break;
     }
-
-    Isolate* isolate = context->GetIsolate();
-    uint8_t* data = (uint8_t*)wrapper->Data();
-    uint8_t* destBuffer = data + field.Offset();
-
-    const TypeEncoding* fieldEncoding = field.Encoding();
-    switch (fieldEncoding->type) {
-        case BinaryTypeEncodingType::StructDeclarationReference: {
-            Local<Object> obj = value.As<Object>();
-            Local<External> ext = obj->GetInternalField(0).As<External>();
-            StructWrapper* targetStruct = static_cast<StructWrapper*>(ext->Value());
-
-            void* sourceBuffer = targetStruct->Data();
-            size_t fieldSize = field.FFIType()->size;
-            memcpy(destBuffer, sourceBuffer, fieldSize);
-            break;
-        }
-        case BinaryTypeEncodingType::ConstantArrayEncoding: {
-            Interop::WriteValue(context, fieldEncoding, destBuffer, value);
-            break;
-        }
-        case BinaryTypeEncodingType::PointerEncoding: {
-            BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-            tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::Struct, isolate);
-            StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
-            void* data = structWrapper->Data();
-            Interop::SetValue(destBuffer, data);
-            break;
-        }
-        case BinaryTypeEncodingType::UShortEncoding: {
-            unsigned short val = value.As<Number>()->Value();
-            *static_cast<unsigned short*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::ShortEncoding: {
-            short val = value.As<Number>()->Value();
-            *static_cast<short*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::UIntEncoding: {
-            unsigned int val = value.As<Number>()->Value();
-            *static_cast<unsigned int*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::IntEncoding: {
-            int val = value.As<Number>()->Value();
-            *static_cast<int*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::ULongEncoding: {
-            unsigned long val = value.As<Number>()->Value();
-            *static_cast<unsigned long*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::LongEncoding: {
-            long val = value.As<Number>()->Value();
-            *static_cast<long*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::ULongLongEncoding: {
-            unsigned long long val = value.As<Number>()->Value();
-            *static_cast<unsigned long long*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::LongLongEncoding: {
-            long long val = value.As<Number>()->Value();
-            *static_cast<long long*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::FloatEncoding: {
-            float val = value.As<Number>()->Value();
-            *static_cast<float*>((void*)destBuffer) = val;
-            break;
-        }
-        case BinaryTypeEncodingType::DoubleEncoding: {
-            double val = value.As<Number>()->Value();
-            *static_cast<double*>((void*)destBuffer) = val;
-            break;
-        }
-        default: {
-            // TODO: Handle all possible cases
-            tns::Assert(false, isolate);
-        }
+    case BinaryTypeEncodingType::ConstantArrayEncoding: {
+      Interop::WriteValue(context, fieldEncoding, destBuffer, value);
+      break;
     }
+    case BinaryTypeEncodingType::PointerEncoding: {
+      BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+      tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::Struct, isolate);
+      StructWrapper* structWrapper = static_cast<StructWrapper*>(wrapper);
+      void* data = structWrapper->Data();
+      Interop::SetValue(destBuffer, data);
+      break;
+    }
+    case BinaryTypeEncodingType::UShortEncoding: {
+      unsigned short val = value.As<Number>()->Value();
+      *static_cast<unsigned short*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::ShortEncoding: {
+      short val = value.As<Number>()->Value();
+      *static_cast<short*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::UIntEncoding: {
+      unsigned int val = value.As<Number>()->Value();
+      *static_cast<unsigned int*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::IntEncoding: {
+      int val = value.As<Number>()->Value();
+      *static_cast<int*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::ULongEncoding: {
+      unsigned long val = value.As<Number>()->Value();
+      *static_cast<unsigned long*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::LongEncoding: {
+      long val = value.As<Number>()->Value();
+      *static_cast<long*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::ULongLongEncoding: {
+      unsigned long long val = value.As<Number>()->Value();
+      *static_cast<unsigned long long*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::LongLongEncoding: {
+      long long val = value.As<Number>()->Value();
+      *static_cast<long long*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::FloatEncoding: {
+      float val = value.As<Number>()->Value();
+      *static_cast<float*>((void*)destBuffer) = val;
+      break;
+    }
+    case BinaryTypeEncodingType::DoubleEncoding: {
+      double val = value.As<Number>()->Value();
+      *static_cast<double*>((void*)destBuffer) = val;
+      break;
+    }
+    default: {
+      // TODO: Handle all possible cases
+      tns::Assert(false, isolate);
+    }
+  }
 }
 
 Local<v8::Array> Interop::ToArray(Local<Object> object) {
-    if (object->IsArray()) {
-        return object.As<v8::Array>();
+  if (object->IsArray()) {
+    return object.As<v8::Array>();
+  }
+
+  Local<Context> context;
+  bool success = object->GetCreationContext().ToLocal(&context);
+  tns::Assert(success);
+  Isolate* isolate = context->GetIsolate();
+
+  Local<v8::Function> sliceFunc;
+  auto cache = Caches::Get(isolate);
+  Persistent<v8::Function>* poSliceFunc = cache->SliceFunc.get();
+
+  if (poSliceFunc != nullptr) {
+    sliceFunc = poSliceFunc->Get(isolate);
+  } else {
+    std::string source = "Array.prototype.slice";
+    Local<Context> context = isolate->GetCurrentContext();
+    Local<Script> script;
+    if (!Script::Compile(context, tns::ToV8String(isolate, source)).ToLocal(&script)) {
+      tns::Assert(false, isolate);
+    }
+    tns::Assert(!script.IsEmpty(), isolate);
+
+    Local<Value> tempSliceFunc;
+    if (!script->Run(context).ToLocal(&tempSliceFunc)) {
+      tns::Assert(false, isolate);
     }
 
-    Local<Context> context;
-    bool success = object->GetCreationContext().ToLocal(&context);
-    tns::Assert(success);
-    Isolate* isolate = context->GetIsolate();
+    tns::Assert(tempSliceFunc->IsFunction(), isolate);
+    sliceFunc = tempSliceFunc.As<v8::Function>();
+    cache->SliceFunc = std::make_unique<Persistent<v8::Function>>(isolate, sliceFunc);
+  }
 
-    Local<v8::Function> sliceFunc;
-    auto cache = Caches::Get(isolate);
-    Persistent<v8::Function>* poSliceFunc = cache->SliceFunc.get();
+  Local<Value> sliceArgs[1]{object};
 
-    if (poSliceFunc != nullptr) {
-        sliceFunc = poSliceFunc->Get(isolate);
-    } else {
-        std::string source = "Array.prototype.slice";
-        Local<Context> context = isolate->GetCurrentContext();
-        Local<Script> script;
-        if (!Script::Compile(context, tns::ToV8String(isolate, source)).ToLocal(&script)) {
-            tns::Assert(false, isolate);
-        }
-        tns::Assert(!script.IsEmpty(), isolate);
+  Local<Value> result;
+  success = sliceFunc->Call(context, object, 1, sliceArgs).ToLocal(&result);
+  tns::Assert(success, isolate);
 
-        Local<Value> tempSliceFunc;
-        if (!script->Run(context).ToLocal(&tempSliceFunc)) {
-            tns::Assert(false, isolate);
-        }
-
-        tns::Assert(tempSliceFunc->IsFunction(), isolate);
-        sliceFunc = tempSliceFunc.As<v8::Function>();
-        cache->SliceFunc = std::make_unique<Persistent<v8::Function>>(isolate, sliceFunc);
-    }
-
-    Local<Value> sliceArgs[1] { object };
-
-    Local<Value> result;
-    success = sliceFunc->Call(context, object, 1, sliceArgs).ToLocal(&result);
-    tns::Assert(success, isolate);
-
-    return result.As<v8::Array>();
+  return result.As<v8::Array>();
 }
 
 SEL Interop::GetSwizzledMethodSelector(SEL selector) {
-    static robin_hood::unordered_map<SEL, SEL> swizzledMethodSelectorCache;
-    static SpinMutex p;
-    SpinLock lock(p);
-    
-    auto it = swizzledMethodSelectorCache.find(selector);
-    if (it != swizzledMethodSelectorCache.end()) {
-        return it->second;
-    }
-    SEL swizzledMethodSelector = NULL;
+  static robin_hood::unordered_map<SEL, SEL> swizzledMethodSelectorCache;
+  static SpinMutex p;
+  SpinLock lock(p);
 
-    swizzledMethodSelector = sel_registerName((Constants::SwizzledPrefix + std::string(sel_getName(selector))).c_str());
-    // save to cache
-    swizzledMethodSelectorCache.emplace(selector, swizzledMethodSelector);
-    
-    return swizzledMethodSelector;
+  auto it = swizzledMethodSelectorCache.find(selector);
+  if (it != swizzledMethodSelectorCache.end()) {
+    return it->second;
+  }
+  SEL swizzledMethodSelector = NULL;
+
+  swizzledMethodSelector =
+      sel_registerName((Constants::SwizzledPrefix + std::string(sel_getName(selector))).c_str());
+  // save to cache
+  swizzledMethodSelectorCache.emplace(selector, swizzledMethodSelector);
+
+  return swizzledMethodSelector;
 }
 
 Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
-    int initialParameterIndex = methodCall.isPrimitiveFunction_ ? 0 : 2;
+  int initialParameterIndex = methodCall.isPrimitiveFunction_ ? 0 : 2;
 
-    int argsCount = initialParameterIndex + (int)methodCall.args_.Length();
-    int cifArgsCount = methodCall.provideErrorOutParameter_ ? argsCount + 1 : argsCount;
+  int argsCount = initialParameterIndex + (int)methodCall.args_.Length();
+  int cifArgsCount = methodCall.provideErrorOutParameter_ ? argsCount + 1 : argsCount;
 
-    ParametrizedCall* parametrizedCall = ParametrizedCall::Get(methodCall.typeEncoding_, initialParameterIndex, cifArgsCount);
+  ParametrizedCall* parametrizedCall =
+      ParametrizedCall::Get(methodCall.typeEncoding_, initialParameterIndex, cifArgsCount);
 
-    FFICall call(parametrizedCall);
+  FFICall call(parametrizedCall);
 
-    objc_super sup;
+  objc_super sup;
 
-    bool isInstanceMethod = (methodCall.target_ && methodCall.target_ != nil);
+  bool isInstanceMethod = (methodCall.target_ && methodCall.target_ != nil);
 
-    if (initialParameterIndex > 1) {
+  if (initialParameterIndex > 1) {
 #if defined(__x86_64__)
-        if (methodCall.metaType_ == MetaType::Undefined || methodCall.metaType_ == MetaType::Union || methodCall.metaType_ == MetaType::Struct) {
-            const unsigned UNIX64_FLAG_RET_IN_MEM = (1 << 10);
+    if (methodCall.metaType_ == MetaType::Undefined || methodCall.metaType_ == MetaType::Union ||
+        methodCall.metaType_ == MetaType::Struct) {
+      const unsigned UNIX64_FLAG_RET_IN_MEM = (1 << 10);
 
-            ffi_type* returnType = FFICall::GetArgumentType(methodCall.typeEncoding_);
+      ffi_type* returnType = FFICall::GetArgumentType(methodCall.typeEncoding_);
 
-            if (returnType->type == FFI_TYPE_LONGDOUBLE) {
-                methodCall.functionPointer_ = (void*)objc_msgSend_fpret;
-            } else if (returnType->type == FFI_TYPE_STRUCT && (parametrizedCall->Cif->flags & UNIX64_FLAG_RET_IN_MEM)) {
-                if (methodCall.callSuper_) {
-                    methodCall.functionPointer_ = (void*)objc_msgSendSuper_stret;
-                } else {
-                    methodCall.functionPointer_ = (void*)objc_msgSend_stret;
-                }
-            }
+      if (returnType->type == FFI_TYPE_LONGDOUBLE) {
+        methodCall.functionPointer_ = (void*)objc_msgSend_fpret;
+      } else if (returnType->type == FFI_TYPE_STRUCT &&
+                 (parametrizedCall->Cif->flags & UNIX64_FLAG_RET_IN_MEM)) {
+        if (methodCall.callSuper_) {
+          methodCall.functionPointer_ = (void*)objc_msgSendSuper_stret;
+        } else {
+          methodCall.functionPointer_ = (void*)objc_msgSend_stret;
         }
+      }
+    }
 #endif
 
-        SEL selector = methodCall.selector_;
-        if (isInstanceMethod) {
-            SEL swizzledMethodSelector = Interop::GetSwizzledMethodSelector(selector);
-            if ([methodCall.target_ respondsToSelector:swizzledMethodSelector]) {
-                selector = swizzledMethodSelector;
-            }
+    SEL selector = methodCall.selector_;
+    if (isInstanceMethod) {
+      SEL swizzledMethodSelector = Interop::GetSwizzledMethodSelector(selector);
+      if ([methodCall.target_ respondsToSelector:swizzledMethodSelector]) {
+        selector = swizzledMethodSelector;
+      }
 
-            if (methodCall.callSuper_) {
-                sup.receiver = methodCall.target_;
-                sup.super_class = class_getSuperclass(object_getClass(methodCall.target_));
-                Interop::SetValue(call.ArgumentBuffer(0), &sup);
-            } else {
-                Interop::SetValue(call.ArgumentBuffer(0), methodCall.target_);
-            }
-        } else {
-            Interop::SetValue(call.ArgumentBuffer(0), methodCall.clazz_);
-        }
-
-        Interop::SetValue(call.ArgumentBuffer(1), selector);
+      if (methodCall.callSuper_) {
+        sup.receiver = methodCall.target_;
+        sup.super_class = class_getSuperclass(object_getClass(methodCall.target_));
+        Interop::SetValue(call.ArgumentBuffer(0), &sup);
+      } else {
+        Interop::SetValue(call.ArgumentBuffer(0), methodCall.target_);
+      }
+    } else {
+      Interop::SetValue(call.ArgumentBuffer(0), methodCall.clazz_);
     }
 
-    bool isInstanceReturnType = methodCall.typeEncoding_->type == BinaryTypeEncodingType::InstanceTypeEncoding;
-    bool marshalToPrimitive = methodCall.isPrimitiveFunction_ || !isInstanceReturnType;
+    Interop::SetValue(call.ArgumentBuffer(1), selector);
+  }
 
-    Interop::SetFFIParams(methodCall.context_, methodCall.typeEncoding_, &call, argsCount, initialParameterIndex, methodCall.args_);
+  bool isInstanceReturnType =
+      methodCall.typeEncoding_->type == BinaryTypeEncodingType::InstanceTypeEncoding;
+  bool marshalToPrimitive = methodCall.isPrimitiveFunction_ || !isInstanceReturnType;
 
-    void* errorRef = nullptr;
-    if (methodCall.provideErrorOutParameter_) {
-        void* dest = call.ArgumentBuffer(argsCount);
-        errorRef = malloc(ffi_type_pointer.size);
-        Interop::SetValue(dest, errorRef);
+  Interop::SetFFIParams(methodCall.context_, methodCall.typeEncoding_, &call, argsCount,
+                        initialParameterIndex, methodCall.args_);
+
+  void* errorRef = nullptr;
+  if (methodCall.provideErrorOutParameter_) {
+    void* dest = call.ArgumentBuffer(argsCount);
+    errorRef = malloc(ffi_type_pointer.size);
+    Interop::SetValue(dest, errorRef);
+  }
+
+  @try {
+    ffi_call(parametrizedCall->Cif, FFI_FN(methodCall.functionPointer_), call.ResultBuffer(),
+             call.ArgsArray());
+  } @catch (NSException* e) {
+    std::string message = [[e description] UTF8String];
+    throw NativeScriptException(message);
+  }
+
+  if (errorRef != nullptr) {
+    NSError* __strong* errorPtr = (NSError * __strong*)errorRef;
+    NSError* error = errorPtr[0];
+    std::free(errorRef);
+    if (error) {
+      // Create JS Error with localizedDescription, attach code, domain and nativeException,
+      // and throw it into V8 so JS catch handlers receive it (with proper stack).
+      Isolate* isolate = methodCall.context_->GetIsolate();
+      Local<Context> context = isolate->GetCurrentContext();
+
+      Local<Value> jsErrVal =
+          Exception::Error(tns::ToV8String(isolate, [[error localizedDescription] UTF8String]));
+      if (jsErrVal.IsEmpty() || !jsErrVal->IsObject()) {
+        // Fallback: if for some reason we cannot create an Error object, throw a generic
+        // NativeScriptException
+        throw NativeScriptException([[error localizedDescription] UTF8String]);
+      }
+
+      Local<Object> jsErrObj = jsErrVal.As<Object>();
+
+      // Attach the NSError code (number) and domain (string)
+      jsErrObj
+          ->Set(context, tns::ToV8String(isolate, "code"),
+                Number::New(isolate, (double)[error code]))
+          .FromMaybe(false);
+      if (error.domain) {
+        jsErrObj
+            ->Set(context, tns::ToV8String(isolate, "domain"),
+                  tns::ToV8String(isolate, [error.domain UTF8String]))
+            .FromMaybe(false);
+      } else {
+        jsErrObj->Set(context, tns::ToV8String(isolate, "domain"), Null(isolate)).FromMaybe(false);
+      }
+
+      // Wrap the native NSError instance into a JS object and attach as nativeException
+      ObjCDataWrapper* wrapper = new ObjCDataWrapper(error);
+      Local<Value> nativeWrapper =
+          ArgConverter::CreateJsWrapper(context, wrapper, Local<Object>(), true);
+      jsErrObj->Set(context, tns::ToV8String(isolate, "nativeException"), nativeWrapper)
+          .FromMaybe(false);
+
+      // Ensure the Error has a proper 'name' property.
+      jsErrObj->Set(context, tns::ToV8String(isolate, "name"), tns::ToV8String(isolate, "NSError"))
+          .FromMaybe(false);
+
+      // Throw the JS Error with full stack information — V8 will populate the stack for the created
+      // Error object.
+      isolate->ThrowException(jsErrObj);
+      return Local<Value>();
     }
+  }
 
-    @try {
-        ffi_call(parametrizedCall->Cif, FFI_FN(methodCall.functionPointer_), call.ResultBuffer(), call.ArgsArray());
-    } @catch (NSException* e) {
-        std::string message = [[e description] UTF8String];
-        throw NativeScriptException(message);
-    }
+  Local<Value> result = Interop::GetResult(
+      methodCall.context_, methodCall.typeEncoding_, &call, marshalToPrimitive, nullptr, false,
+      methodCall.ownsReturnedObject_, methodCall.returnsUnmanaged_, methodCall.isInitializer_);
 
-    if (errorRef != nullptr) {
-        NSError*__strong* errorPtr = (NSError*__strong*)errorRef;
-        NSError* error = errorPtr[0];
-        std::free(errorRef);
-        if (error) {
-            // Create JS Error with localizedDescription, attach code, domain and nativeException,
-            // and throw it into V8 so JS catch handlers receive it (with proper stack).
-            Isolate* isolate = methodCall.context_->GetIsolate();
-            Local<Context> context = isolate->GetCurrentContext();
-
-            Local<Value> jsErrVal = Exception::Error(tns::ToV8String(isolate, [[error localizedDescription] UTF8String]));
-            if (jsErrVal.IsEmpty() || !jsErrVal->IsObject()) {
-                // Fallback: if for some reason we cannot create an Error object, throw a generic NativeScriptException
-                throw NativeScriptException([[error localizedDescription] UTF8String]);
-            }
-
-            Local<Object> jsErrObj = jsErrVal.As<Object>();
-
-            // Attach the NSError code (number) and domain (string)
-            jsErrObj->Set(context, tns::ToV8String(isolate, "code"), Number::New(isolate, (double)[error code])).FromMaybe(false);
-            if (error.domain) {
-                jsErrObj->Set(context, tns::ToV8String(isolate, "domain"), tns::ToV8String(isolate, [error.domain UTF8String])).FromMaybe(false);
-            } else {
-                jsErrObj->Set(context, tns::ToV8String(isolate, "domain"), Null(isolate)).FromMaybe(false);
-            }
-
-            // Wrap the native NSError instance into a JS object and attach as nativeException
-            ObjCDataWrapper* wrapper = new ObjCDataWrapper(error);
-            Local<Value> nativeWrapper = ArgConverter::CreateJsWrapper(context, wrapper, Local<Object>(), true);
-            jsErrObj->Set(context, tns::ToV8String(isolate, "nativeException"), nativeWrapper).FromMaybe(false);
-
-            // Ensure the Error has a proper 'name' property.
-            jsErrObj->Set(context, tns::ToV8String(isolate, "name"), tns::ToV8String(isolate, "NSError")).FromMaybe(false);
-
-            // Throw the JS Error with full stack information — V8 will populate the stack for the created Error object.
-            isolate->ThrowException(jsErrObj);
-            return Local<Value>();
-        }
-    }
-
-    Local<Value> result = Interop::GetResult(
-        methodCall.context_,
-        methodCall.typeEncoding_,
-        &call,
-        marshalToPrimitive,
-        nullptr,
-        false,
-        methodCall.ownsReturnedObject_,
-        methodCall.returnsUnmanaged_,
-        methodCall.isInitializer_);
-
-    return result;
+  return result;
 }
 
 // MARK: - Debug Messages for the runtime
 
-void ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(Local<Context> context, const TypeEncoding* typeEncoding, void* dest, Local<Value> arg) {
-    Isolate* isolate = context->GetIsolate();
-    std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
-    Local<Value> originArg = arg;
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-        if (originArg->IsObject()) {
-            Local<Object> originObj = originArg.As<Object>();
-            if ((originObj->IsArrayBuffer() || originObj->IsArrayBufferView()) &&
-                destName != "NSArray") {
-                tns::StopExecutionAndLogStackTrace(isolate);
-            }
-        }
-        if (destName == "NSString" && tns::IsNumber(originArg)) {
-            tns::StopExecutionAndLogStackTrace(isolate);
-        }
-        if (destName == "NSString" && tns::IsBool(originArg)) {
-            tns::StopExecutionAndLogStackTrace(isolate);
-        }
-        if (destName == "NSString" && tns::IsArrayOrArrayLike(isolate, originArg)) {
-            tns::StopExecutionAndLogStackTrace(isolate);
-        }
+void ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(Local<Context> context,
+                                                                  const TypeEncoding* typeEncoding,
+                                                                  void* dest, Local<Value> arg) {
+  Isolate* isolate = context->GetIsolate();
+  std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+  Local<Value> originArg = arg;
+  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+    if (originArg->IsObject()) {
+      Local<Object> originObj = originArg.As<Object>();
+      if ((originObj->IsArrayBuffer() || originObj->IsArrayBufferView() ||
+           originObj->IsSharedArrayBuffer()) &&
+          destName != "NSArray") {
+        tns::StopExecutionAndLogStackTrace(isolate);
+      }
     }
+    if (destName == "NSString" && tns::IsNumber(originArg)) {
+      tns::StopExecutionAndLogStackTrace(isolate);
+    }
+    if (destName == "NSString" && tns::IsBool(originArg)) {
+      tns::StopExecutionAndLogStackTrace(isolate);
+    }
+    if (destName == "NSString" && tns::IsArrayOrArrayLike(isolate, originArg)) {
+      tns::StopExecutionAndLogStackTrace(isolate);
+    }
+  }
 }
 
 bool IsTypeEncondingHandldedByDebugMessages(const TypeEncoding* typeEncoding) {
-    if (typeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference &&
-        typeEncoding->type != BinaryTypeEncodingType::StructDeclarationReference &&
-        typeEncoding->type != BinaryTypeEncodingType::IdEncoding) {
-        return true;
-    } else {
-        return false;
-    }
+  if (typeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference &&
+      typeEncoding->type != BinaryTypeEncodingType::StructDeclarationReference &&
+      typeEncoding->type != BinaryTypeEncodingType::IdEncoding) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
-void LogWriteValueTraceMessage(Local<Context> context, const TypeEncoding* typeEncoding, void* dest, Local<Value> arg) {
-    Isolate* isolate = context->GetIsolate();
-    std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
-    std::string originName = tns::ToString(isolate, arg);
-    if (originName == "") {
-        // empty string
-        originName = "\"\"";
-    }
-    // NOTE: stringWithFormat is slow, perhaps use different c string concatenation?
-    NSString* message = [NSString stringWithFormat:@"Interop::WriteValue: from {%s} to {%s}", originName.c_str(), destName.c_str()];
-    Log(@"%@", message);
+void LogWriteValueTraceMessage(Local<Context> context, const TypeEncoding* typeEncoding, void* dest,
+                               Local<Value> arg) {
+  Isolate* isolate = context->GetIsolate();
+  std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+  std::string originName = tns::ToString(isolate, arg);
+  if (originName == "") {
+    // empty string
+    originName = "\"\"";
+  }
+  // NOTE: stringWithFormat is slow, perhaps use different c string concatenation?
+  NSString* message = [NSString stringWithFormat:@"Interop::WriteValue: from {%s} to {%s}",
+                                                 originName.c_str(), destName.c_str()];
+  Log(@"%@", message);
 }
 
-void Interop::ExecuteWriteValueDebugValidationsIfInDebug(Local<Context> context, const TypeEncoding* typeEncoding, void* dest, Local<Value> arg) {
-
-    #ifdef DEBUG
-    id value = Runtime::GetAppConfigValue("logRuntimeDetail");
-    bool logRuntimeDetail = value ? [value boolValue] : false;
-    if (logRuntimeDetail) {
-        if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
-            return;
-        }
-        if (IsTypeEncondingHandldedByDebugMessages(typeEncoding)) {
-            return;
-        }
-        LogWriteValueTraceMessage(context, typeEncoding, dest, arg);
-        ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(context, typeEncoding, dest, arg);
+void Interop::ExecuteWriteValueDebugValidationsIfInDebug(Local<Context> context,
+                                                         const TypeEncoding* typeEncoding,
+                                                         void* dest, Local<Value> arg) {
+#ifdef DEBUG
+  id value = Runtime::GetAppConfigValue("logRuntimeDetail");
+  bool logRuntimeDetail = value ? [value boolValue] : false;
+  if (logRuntimeDetail) {
+    if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
+      return;
     }
-    #endif
+    if (IsTypeEncondingHandldedByDebugMessages(typeEncoding)) {
+      return;
+    }
+    LogWriteValueTraceMessage(context, typeEncoding, dest, arg);
+    ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(context, typeEncoding, dest, arg);
+  }
+#endif
 }
-    
-}
+
+}  // namespace tns

--- a/NativeScript/runtime/InteropTypes.mm
+++ b/NativeScript/runtime/InteropTypes.mm
@@ -1,123 +1,186 @@
 #include <Foundation/Foundation.h>
-#include "SymbolLoader.h"
-#include "Interop.h"
-#include "ObjectManager.h"
-#include "Helpers.h"
 #include "Caches.h"
-#include "NativeScriptException.h"
-#include "FunctionReference.h"
-#include "Reference.h"
-#include "Pointer.h"
 #include "Constants.h"
+#include "FunctionReference.h"
+#include "Helpers.h"
+#include "Interop.h"
+#include "NativeScriptException.h"
+#include "ObjectManager.h"
+#include "Pointer.h"
+#include "Reference.h"
+#include "SymbolLoader.h"
 
 using namespace v8;
 
 namespace tns {
 
 void Interop::RegisterInteropTypes(Local<Context> context) {
-    Isolate* isolate = context->GetIsolate();
-    Local<Object> global = context->Global();
+  Isolate* isolate = context->GetIsolate();
+  Local<Object> global = context->Global();
 
-    Local<Object> interop = Object::New(isolate);
-    Local<Object> types = Object::New(isolate);
+  Local<Object> interop = Object::New(isolate);
+  Local<Object> types = Object::New(isolate);
 
-    Reference::Register(context, interop);
-    Pointer::Register(context, interop);
-    FunctionReference::Register(context, interop);
-    RegisterBufferFromDataFunction(context, interop);
-    RegisterStringFromCString(context, interop);
-    RegisterHandleOfFunction(context, interop);
-    RegisterAllocFunction(context, interop);
-    RegisterFreeFunction(context, interop);
-    RegisterAdoptFunction(context, interop);
-    RegisterSizeOfFunction(context, interop);
+  Reference::Register(context, interop);
+  Pointer::Register(context, interop);
+  FunctionReference::Register(context, interop);
+  RegisterBufferFromDataFunction(context, interop);
+  RegisterStringFromCString(context, interop);
+  RegisterHandleOfFunction(context, interop);
+  RegisterAllocFunction(context, interop);
+  RegisterFreeFunction(context, interop);
+  RegisterAdoptFunction(context, interop);
+  RegisterSizeOfFunction(context, interop);
 
-    RegisterInteropType(context, types, "noop", new PrimitiveDataWrapper(ffi_type_pointer.size, CreateEncoding(BinaryTypeEncodingType::VoidEncoding), true));
-    RegisterInteropType(context, types, "void", new PrimitiveDataWrapper(0, CreateEncoding(BinaryTypeEncodingType::VoidEncoding), true));
-    RegisterInteropType(context, types, "bool", new PrimitiveDataWrapper(sizeof(bool), CreateEncoding(BinaryTypeEncodingType::BoolEncoding), true));
-    RegisterInteropType(context, types, "uint8", new PrimitiveDataWrapper(ffi_type_uint8.size, CreateEncoding(BinaryTypeEncodingType::UCharEncoding), true));
-    RegisterInteropType(context, types, "int8", new PrimitiveDataWrapper(ffi_type_sint8.size, CreateEncoding(BinaryTypeEncodingType::CharEncoding), true));
-    RegisterInteropType(context, types, "uint16", new PrimitiveDataWrapper(ffi_type_uint16.size, CreateEncoding(BinaryTypeEncodingType::UShortEncoding), true));
-    RegisterInteropType(context, types, "int16", new PrimitiveDataWrapper(ffi_type_sint16.size, CreateEncoding(BinaryTypeEncodingType::ShortEncoding), true));
-    RegisterInteropType(context, types, "uint32", new PrimitiveDataWrapper(ffi_type_uint32.size, CreateEncoding(BinaryTypeEncodingType::UIntEncoding), true));
-    RegisterInteropType(context, types, "int32", new PrimitiveDataWrapper(ffi_type_sint32.size, CreateEncoding(BinaryTypeEncodingType::IntEncoding), true));
-    RegisterInteropType(context, types, "uint64", new PrimitiveDataWrapper(ffi_type_uint64.size, CreateEncoding(BinaryTypeEncodingType::ULongEncoding), true));
-    RegisterInteropType(context, types, "int64", new PrimitiveDataWrapper(ffi_type_sint64.size, CreateEncoding(BinaryTypeEncodingType::LongEncoding), true));
-    RegisterInteropType(context, types, "ulong", new PrimitiveDataWrapper(ffi_type_ulong.size, CreateEncoding(BinaryTypeEncodingType::ULongLongEncoding), true));
-    RegisterInteropType(context, types, "slong", new PrimitiveDataWrapper(ffi_type_slong.size, CreateEncoding(BinaryTypeEncodingType::LongLongEncoding), true));
-    RegisterInteropType(context, types, "float", new PrimitiveDataWrapper(ffi_type_float.size, CreateEncoding(BinaryTypeEncodingType::FloatEncoding), true));
-    RegisterInteropType(context, types, "double", new PrimitiveDataWrapper(ffi_type_double.size, CreateEncoding(BinaryTypeEncodingType::DoubleEncoding), true));
+  RegisterInteropType(
+      context, types, "noop",
+      new PrimitiveDataWrapper(ffi_type_pointer.size,
+                               CreateEncoding(BinaryTypeEncodingType::VoidEncoding), true));
+  RegisterInteropType(
+      context, types, "void",
+      new PrimitiveDataWrapper(0, CreateEncoding(BinaryTypeEncodingType::VoidEncoding), true));
+  RegisterInteropType(
+      context, types, "bool",
+      new PrimitiveDataWrapper(sizeof(bool), CreateEncoding(BinaryTypeEncodingType::BoolEncoding),
+                               true));
+  RegisterInteropType(
+      context, types, "uint8",
+      new PrimitiveDataWrapper(ffi_type_uint8.size,
+                               CreateEncoding(BinaryTypeEncodingType::UCharEncoding), true));
+  RegisterInteropType(
+      context, types, "int8",
+      new PrimitiveDataWrapper(ffi_type_sint8.size,
+                               CreateEncoding(BinaryTypeEncodingType::CharEncoding), true));
+  RegisterInteropType(
+      context, types, "uint16",
+      new PrimitiveDataWrapper(ffi_type_uint16.size,
+                               CreateEncoding(BinaryTypeEncodingType::UShortEncoding), true));
+  RegisterInteropType(
+      context, types, "int16",
+      new PrimitiveDataWrapper(ffi_type_sint16.size,
+                               CreateEncoding(BinaryTypeEncodingType::ShortEncoding), true));
+  RegisterInteropType(
+      context, types, "uint32",
+      new PrimitiveDataWrapper(ffi_type_uint32.size,
+                               CreateEncoding(BinaryTypeEncodingType::UIntEncoding), true));
+  RegisterInteropType(
+      context, types, "int32",
+      new PrimitiveDataWrapper(ffi_type_sint32.size,
+                               CreateEncoding(BinaryTypeEncodingType::IntEncoding), true));
+  RegisterInteropType(
+      context, types, "uint64",
+      new PrimitiveDataWrapper(ffi_type_uint64.size,
+                               CreateEncoding(BinaryTypeEncodingType::ULongEncoding), true));
+  RegisterInteropType(
+      context, types, "int64",
+      new PrimitiveDataWrapper(ffi_type_sint64.size,
+                               CreateEncoding(BinaryTypeEncodingType::LongEncoding), true));
+  RegisterInteropType(
+      context, types, "ulong",
+      new PrimitiveDataWrapper(ffi_type_ulong.size,
+                               CreateEncoding(BinaryTypeEncodingType::ULongLongEncoding), true));
+  RegisterInteropType(
+      context, types, "slong",
+      new PrimitiveDataWrapper(ffi_type_slong.size,
+                               CreateEncoding(BinaryTypeEncodingType::LongLongEncoding), true));
+  RegisterInteropType(
+      context, types, "float",
+      new PrimitiveDataWrapper(ffi_type_float.size,
+                               CreateEncoding(BinaryTypeEncodingType::FloatEncoding), true));
+  RegisterInteropType(
+      context, types, "double",
+      new PrimitiveDataWrapper(ffi_type_double.size,
+                               CreateEncoding(BinaryTypeEncodingType::DoubleEncoding), true));
 
-    RegisterInteropType(context, types, "id", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::IdEncoding), true));
-//    RegisterInteropType(context, types, "UTF8CString", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
-    RegisterInteropType(context, types, "unichar", new PrimitiveDataWrapper(ffi_type_ushort.size, CreateEncoding(BinaryTypeEncodingType::UnicharEncoding), true));
-    RegisterInteropType(context, types, "protocol", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ProtocolEncoding), true));
-    RegisterInteropType(context, types, "class", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ClassEncoding), true));
-    RegisterInteropType(context, types, "selector", new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::SelectorEncoding), true));
+  RegisterInteropType(context, types, "id",
+                      new PrimitiveDataWrapper(
+                          sizeof(void*), CreateEncoding(BinaryTypeEncodingType::IdEncoding), true));
+  //    RegisterInteropType(context, types, "UTF8CString", new PrimitiveDataWrapper(sizeof(void*),
+  //    CreateEncoding(BinaryTypeEncodingType::VoidEncoding)));
+  RegisterInteropType(
+      context, types, "unichar",
+      new PrimitiveDataWrapper(ffi_type_ushort.size,
+                               CreateEncoding(BinaryTypeEncodingType::UnicharEncoding), true));
+  RegisterInteropType(
+      context, types, "protocol",
+      new PrimitiveDataWrapper(sizeof(void*),
+                               CreateEncoding(BinaryTypeEncodingType::ProtocolEncoding), true));
+  RegisterInteropType(
+      context, types, "class",
+      new PrimitiveDataWrapper(sizeof(void*), CreateEncoding(BinaryTypeEncodingType::ClassEncoding),
+                               true));
+  RegisterInteropType(
+      context, types, "selector",
+      new PrimitiveDataWrapper(sizeof(void*),
+                               CreateEncoding(BinaryTypeEncodingType::SelectorEncoding), true));
 
-    bool success = interop->Set(context, tns::ToV8String(isolate, "types"), types).FromMaybe(false);
-    tns::Assert(success, isolate);
+  bool success = interop->Set(context, tns::ToV8String(isolate, "types"), types).FromMaybe(false);
+  tns::Assert(success, isolate);
 
-    success = global->Set(context, tns::ToV8String(isolate, "interop"), interop).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = global->Set(context, tns::ToV8String(isolate, "interop"), interop).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 Local<Object> Interop::GetInteropType(Local<Context> context, BinaryTypeEncodingType type) {
-    Isolate* isolate = context->GetIsolate();
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-    auto it = cache->PrimitiveInteropTypes.find(type);
-    if (it != cache->PrimitiveInteropTypes.end()) {
-        return it->second->Get(isolate);
-    }
+  Isolate* isolate = context->GetIsolate();
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+  auto it = cache->PrimitiveInteropTypes.find(type);
+  if (it != cache->PrimitiveInteropTypes.end()) {
+    return it->second->Get(isolate);
+  }
 
-    return Local<Object>();
+  return Local<Object>();
 }
 
-void Interop::RegisterInteropType(Local<Context> context, Local<Object> types, std::string name, PrimitiveDataWrapper* wrapper, bool autoDelete) {
-    Isolate* isolate = context->GetIsolate();
-    Local<FunctionTemplate> ctorFuncTemplate = FunctionTemplate::New(isolate, nullptr);
-    ctorFuncTemplate->SetClassName(tns::ToV8String(isolate, name));
-    ctorFuncTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+void Interop::RegisterInteropType(Local<Context> context, Local<Object> types, std::string name,
+                                  PrimitiveDataWrapper* wrapper, bool autoDelete) {
+  Isolate* isolate = context->GetIsolate();
+  Local<FunctionTemplate> ctorFuncTemplate = FunctionTemplate::New(isolate, nullptr);
+  ctorFuncTemplate->SetClassName(tns::ToV8String(isolate, name));
+  ctorFuncTemplate->InstanceTemplate()->SetInternalFieldCount(1);
 
-    Local<v8::Function> ctorFunc;
-    if (!ctorFuncTemplate->GetFunction(context).ToLocal(&ctorFunc)) {
-        tns::Assert(false, isolate);
+  Local<v8::Function> ctorFunc;
+  if (!ctorFuncTemplate->GetFunction(context).ToLocal(&ctorFunc)) {
+    tns::Assert(false, isolate);
+  }
+
+  Local<Value> value;
+  if (!ctorFunc->CallAsConstructor(context, 0, nullptr).ToLocal(&value) || value.IsEmpty() ||
+      !value->IsObject()) {
+    tns::Assert(false, isolate);
+  }
+  Local<Object> result = value.As<Object>();
+
+  tns::SetValue(isolate, result, wrapper);
+  bool success = types->Set(context, tns::ToV8String(isolate, name), result).FromMaybe(false);
+
+  BinaryTypeEncodingType type = wrapper->TypeEncoding()->type;
+  std::shared_ptr<Caches> cache = Caches::Get(isolate);
+  auto it = cache->PrimitiveInteropTypes.find(type);
+  if (it == cache->PrimitiveInteropTypes.end()) {
+    auto persistentObj = std::make_unique<Persistent<Object>>(isolate, result);
+    if (autoDelete) {
+      persistentObj->SetWrapperClassId(Constants::ClassTypes::DataWrapper);
     }
+    cache->PrimitiveInteropTypes.emplace(type, std::move(persistentObj));
+  } else if (autoDelete) {
+    // TODO: review this. We send the void encoding multiple times so this is just a dirty fallback
+    // maybe we should have another method on the ObjectManager for cleaning up these
+    cache->registerCacheBoundObject(wrapper);
+  }
 
-    Local<Value> value;
-    if (!ctorFunc->CallAsConstructor(context, 0, nullptr).ToLocal(&value) || value.IsEmpty() || !value->IsObject()) {
-        tns::Assert(false, isolate);
-    }
-    Local<Object> result = value.As<Object>();
-
-    tns::SetValue(isolate, result, wrapper);
-    bool success = types->Set(context, tns::ToV8String(isolate, name), result).FromMaybe(false);
-
-    BinaryTypeEncodingType type = wrapper->TypeEncoding()->type;
-    std::shared_ptr<Caches> cache = Caches::Get(isolate);
-    auto it = cache->PrimitiveInteropTypes.find(type);
-    if (it == cache->PrimitiveInteropTypes.end()) {
-        auto persistentObj = std::make_unique<Persistent<Object>>(isolate, result);
-        if (autoDelete) {
-            persistentObj->SetWrapperClassId(Constants::ClassTypes::DataWrapper);
-        }
-        cache->PrimitiveInteropTypes.emplace(type, std::move(persistentObj));
-    } else if (autoDelete) {
-        // TODO: review this. We send the void encoding multiple times so this is just a dirty fallback
-        // maybe we should have another method on the ObjectManager for cleaning up these
-        cache->registerCacheBoundObject(wrapper);
-    }
-
-    tns::Assert(success, isolate);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterBufferFromDataFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+  Local<v8::Function> func;
+  bool success =
+      v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
         tns::Assert(info.Length() == 1 && info[0]->IsObject(), isolate);
         Local<Object> arg = info[0].As<Object>();
-        tns::Assert(arg->InternalFieldCount() > 0 && arg->GetInternalField(0)->IsExternal(), isolate);
+        tns::Assert(arg->InternalFieldCount() > 0 && arg->GetInternalField(0)->IsExternal(),
+                    isolate);
 
         Local<External> ext = arg->GetInternalField(0).As<External>();
         ObjCDataWrapper* wrapper = static_cast<ObjCDataWrapper*>(ext->Value());
@@ -128,352 +191,355 @@ void Interop::RegisterBufferFromDataFunction(Local<Context> context, Local<Objec
         size_t length = [obj length];
         void* data = const_cast<void*>([obj bytes]);
 
-        std::unique_ptr<v8::BackingStore> backingStore = ArrayBuffer::NewBackingStore(data, length, [](void*, size_t, void*) { }, nullptr);
+        std::unique_ptr<v8::BackingStore> backingStore =
+            ArrayBuffer::NewBackingStore(data, length, [](void*, size_t, void*) {}, nullptr);
 
         Local<ArrayBuffer> result = ArrayBuffer::New(isolate, std::move(backingStore));
         info.GetReturnValue().Set(result);
-    }).ToLocal(&func);
+      }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "bufferFromData"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success =
+      interop->Set(context, tns::ToV8String(isolate, "bufferFromData"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterStringFromCString(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+  Local<v8::Function> func;
+  bool success =
+      v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
         Isolate* isolate = info.GetIsolate();
         tns::Assert(info.Length() >= 1 && info[0]->IsObject(), isolate);
         Local<Object> arg = info[0].As<Object>();
         int stringLength = -1;
-        if(info.Length() >= 2 && !info[1].IsEmpty() && !info[1]->IsNullOrUndefined()) {
-            auto desiredLength = ToNumber(isolate, info[1]);
-            if (desiredLength != NAN) {
-                stringLength = desiredLength;
-            }
+        if (info.Length() >= 2 && !info[1].IsEmpty() && !info[1]->IsNullOrUndefined()) {
+          auto desiredLength = ToNumber(isolate, info[1]);
+          if (desiredLength != NAN) {
+            stringLength = desiredLength;
+          }
         }
-        tns::Assert(arg->InternalFieldCount() > 0 && arg->GetInternalField(0)->IsExternal(), isolate);
+        tns::Assert(arg->InternalFieldCount() > 0 && arg->GetInternalField(0)->IsExternal(),
+                    isolate);
 
         Local<External> ext = arg->GetInternalField(0).As<External>();
         BaseDataWrapper* wrapper = static_cast<BaseDataWrapper*>(ext->Value());
         tns::Assert(wrapper != nullptr);
         char* data = nullptr;
         switch (wrapper->Type()) {
-            case WrapperType::Pointer:
-                {
-                    PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-                    data = static_cast<char*>(pointerWrapper->Data());
-                }
-                break;
-            case WrapperType::Reference:
-            {
-                ReferenceWrapper* referenceWrapper = static_cast<ReferenceWrapper*>(wrapper);
-                if (referenceWrapper->Data() != nullptr) {
-                    data = static_cast<char*>(referenceWrapper->Data());
-                    break;
-                }
-                auto wrappedValue = referenceWrapper->Value()->Get(isolate);
-                auto wrappedWrapper = tns::GetValue(isolate, wrappedValue);
-                tns::Assert(wrappedWrapper->Type() == WrapperType::Pointer);
-                data = static_cast<char*>((static_cast<PointerWrapper*>(wrappedWrapper))->Data());
+          case WrapperType::Pointer: {
+            PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
+            data = static_cast<char*>(pointerWrapper->Data());
+          } break;
+          case WrapperType::Reference: {
+            ReferenceWrapper* referenceWrapper = static_cast<ReferenceWrapper*>(wrapper);
+            if (referenceWrapper->Data() != nullptr) {
+              data = static_cast<char*>(referenceWrapper->Data());
+              break;
             }
-            default:
-                break;
+            auto wrappedValue = referenceWrapper->Value()->Get(isolate);
+            auto wrappedWrapper = tns::GetValue(isolate, wrappedValue);
+            tns::Assert(wrappedWrapper->Type() == WrapperType::Pointer);
+            data = static_cast<char*>((static_cast<PointerWrapper*>(wrappedWrapper))->Data());
+          }
+          default:
+            break;
         }
         tns::Assert(data != nullptr);
 
-        auto result = v8::String::NewFromUtf8(isolate, data, v8::NewStringType::kNormal, stringLength).ToLocalChecked();
+        auto result =
+            v8::String::NewFromUtf8(isolate, data, v8::NewStringType::kNormal, stringLength)
+                .ToLocalChecked();
         info.GetReturnValue().Set(result);
-    }).ToLocal(&func);
+      }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "stringFromCString"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success =
+      interop->Set(context, tns::ToV8String(isolate, "stringFromCString"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterHandleOfFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-        Isolate* isolate = info.GetIsolate();
-        Local<Context> context = isolate->GetCurrentContext();
-        tns::Assert(info.Length() == 1, isolate);
-        try {
-            Local<Value> arg = info[0];
+  Local<v8::Function> func;
+  bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+                   Isolate* isolate = info.GetIsolate();
+                   Local<Context> context = isolate->GetCurrentContext();
+                   tns::Assert(info.Length() == 1, isolate);
+                   try {
+                     Local<Value> arg = info[0];
 
-            Local<Value> result = Interop::HandleOf(context, arg);
-            if (result.IsEmpty()) {
-                throw NativeScriptException("Unknown type");
-            }
+                     Local<Value> result = Interop::HandleOf(context, arg);
+                     if (result.IsEmpty()) {
+                       throw NativeScriptException("Unknown type");
+                     }
 
-            info.GetReturnValue().Set(result);
-        } catch (NativeScriptException& ex) {
-            ex.ReThrowToV8(isolate);
-        }
-    }).ToLocal(&func);
+                     info.GetReturnValue().Set(result);
+                   } catch (NativeScriptException& ex) {
+                     ex.ReThrowToV8(isolate);
+                   }
+                 }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "handleof"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = interop->Set(context, tns::ToV8String(isolate, "handleof"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterAllocFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-        Isolate* isolate = info.GetIsolate();
-        tns::Assert(info.Length() == 1, isolate);
-        tns::Assert(tns::IsNumber(info[0]), isolate);
+  Local<v8::Function> func;
+  bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+                   Isolate* isolate = info.GetIsolate();
+                   tns::Assert(info.Length() == 1, isolate);
+                   tns::Assert(tns::IsNumber(info[0]), isolate);
 
-        Local<Context> context = isolate->GetCurrentContext();
-        Local<Number> arg = info[0].As<Number>();
-        int32_t value;
-        tns::Assert(arg->Int32Value(context).To(&value), isolate);
+                   Local<Context> context = isolate->GetCurrentContext();
+                   Local<Number> arg = info[0].As<Number>();
+                   int32_t value;
+                   tns::Assert(arg->Int32Value(context).To(&value), isolate);
 
-        size_t size = static_cast<size_t>(value);
+                   size_t size = static_cast<size_t>(value);
 
-        void* data = calloc(1, size);
+                   void* data = calloc(1, size);
 
-        Local<Value> pointerInstance = Pointer::NewInstance(context, data);
-        PointerWrapper* wrapper = static_cast<PointerWrapper*>(pointerInstance.As<Object>()->GetInternalField(0).As<External>()->Value());
-        wrapper->SetAdopted(true);
-        info.GetReturnValue().Set(pointerInstance);
-    }).ToLocal(&func);
+                   Local<Value> pointerInstance = Pointer::NewInstance(context, data);
+                   PointerWrapper* wrapper = static_cast<PointerWrapper*>(
+                       pointerInstance.As<Object>()->GetInternalField(0).As<External>()->Value());
+                   wrapper->SetAdopted(true);
+                   info.GetReturnValue().Set(pointerInstance);
+                 }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "alloc"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = interop->Set(context, tns::ToV8String(isolate, "alloc"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterFreeFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-        Isolate* isolate = info.GetIsolate();
-        tns::Assert(info.Length() == 1, isolate);
-        Local<Value> arg = info[0];
+  Local<v8::Function> func;
+  bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+                   Isolate* isolate = info.GetIsolate();
+                   tns::Assert(info.Length() == 1, isolate);
+                   Local<Value> arg = info[0];
 
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        tns::Assert(wrapper->Type() == WrapperType::Pointer, isolate);
+                   BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+                   tns::Assert(wrapper->Type() == WrapperType::Pointer, isolate);
 
-        PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
-        if (pw->IsAdopted()) {
-            // TODO: throw an error that the pointer is adopted
-            return;
-        }
+                   PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
+                   if (pw->IsAdopted()) {
+                     // TODO: throw an error that the pointer is adopted
+                     return;
+                   }
 
-        if (pw->Data() != nullptr) {
-            std::free(pw->Data());
-        }
+                   if (pw->Data() != nullptr) {
+                     std::free(pw->Data());
+                   }
 
-        info.GetReturnValue().SetUndefined();
-    }).ToLocal(&func);
+                   info.GetReturnValue().SetUndefined();
+                 }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "free"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = interop->Set(context, tns::ToV8String(isolate, "free"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterAdoptFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-        Isolate* isolate = info.GetIsolate();
-        tns::Assert(info.Length() == 1, isolate);
-        Local<Value> arg = info[0];
+  Local<v8::Function> func;
+  bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+                   Isolate* isolate = info.GetIsolate();
+                   tns::Assert(info.Length() == 1, isolate);
+                   Local<Value> arg = info[0];
 
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
-        tns::Assert(wrapper->Type() == WrapperType::Pointer, isolate);
+                   BaseDataWrapper* wrapper = tns::GetValue(isolate, arg);
+                   tns::Assert(wrapper->Type() == WrapperType::Pointer, isolate);
 
-        PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
-        pw->SetAdopted(true);
+                   PointerWrapper* pw = static_cast<PointerWrapper*>(wrapper);
+                   pw->SetAdopted(true);
 
-        info.GetReturnValue().Set(arg);
-    }).ToLocal(&func);
+                   info.GetReturnValue().Set(arg);
+                 }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "adopt"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = interop->Set(context, tns::ToV8String(isolate, "adopt"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 void Interop::RegisterSizeOfFunction(Local<Context> context, Local<Object> interop) {
-    Local<v8::Function> func;
-    bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
-        Isolate* isolate = info.GetIsolate();
-        tns::Assert(info.Length() == 1, isolate);
-        try {
-            Local<Value> arg = info[0];
-            size_t size = 0;
+  Local<v8::Function> func;
+  bool success = v8::Function::New(context, [](const FunctionCallbackInfo<Value>& info) {
+                   Isolate* isolate = info.GetIsolate();
+                   tns::Assert(info.Length() == 1, isolate);
+                   try {
+                     Local<Value> arg = info[0];
+                     size_t size = 0;
 
-            if (!arg->IsNullOrUndefined()) {
-                if (arg->IsObject()) {
-                    Local<Object> obj = arg.As<Object>();
-                    if (BaseDataWrapper* wrapper = tns::GetValue(isolate, obj)) {
-                        switch (wrapper->Type()) {
-                            case WrapperType::ObjCClass:
-                            case WrapperType::ObjCProtocol:
-                            case WrapperType::ObjCObject:
-                            case WrapperType::PointerType:
-                            case WrapperType::Pointer:
-                            case WrapperType::Reference:
-                            case WrapperType::ReferenceType:
-                            case WrapperType::Block:
-                            case WrapperType::FunctionReference:
-                            case WrapperType::FunctionReferenceType:
-                            case WrapperType::Function: {
-                                size = sizeof(void*);
-                                break;
-                            }
-                            case WrapperType::Primitive: {
-                                PrimitiveDataWrapper* pw = static_cast<PrimitiveDataWrapper*>(wrapper);
-                                size = pw->Size();
-                                break;
-                            }
-                            case WrapperType::Struct: {
-                                StructWrapper* sw = static_cast<StructWrapper*>(wrapper);
-                                size = sw->StructInfo().FFIType()->size;
-                                break;
-                            }
-                            case WrapperType::StructType: {
-                                StructTypeWrapper* sw = static_cast<StructTypeWrapper*>(wrapper);
-                                StructInfo structInfo = sw->StructInfo();
-                                size = structInfo.FFIType()->size;
-                                break;
-                            }
-                            default:
-                                break;
-                        }
-                    }
-                }
-            }
+                     if (!arg->IsNullOrUndefined()) {
+                       if (arg->IsObject()) {
+                         Local<Object> obj = arg.As<Object>();
+                         if (BaseDataWrapper* wrapper = tns::GetValue(isolate, obj)) {
+                           switch (wrapper->Type()) {
+                             case WrapperType::ObjCClass:
+                             case WrapperType::ObjCProtocol:
+                             case WrapperType::ObjCObject:
+                             case WrapperType::PointerType:
+                             case WrapperType::Pointer:
+                             case WrapperType::Reference:
+                             case WrapperType::ReferenceType:
+                             case WrapperType::Block:
+                             case WrapperType::FunctionReference:
+                             case WrapperType::FunctionReferenceType:
+                             case WrapperType::Function: {
+                               size = sizeof(void*);
+                               break;
+                             }
+                             case WrapperType::Primitive: {
+                               PrimitiveDataWrapper* pw =
+                                   static_cast<PrimitiveDataWrapper*>(wrapper);
+                               size = pw->Size();
+                               break;
+                             }
+                             case WrapperType::Struct: {
+                               StructWrapper* sw = static_cast<StructWrapper*>(wrapper);
+                               size = sw->StructInfo().FFIType()->size;
+                               break;
+                             }
+                             case WrapperType::StructType: {
+                               StructTypeWrapper* sw = static_cast<StructTypeWrapper*>(wrapper);
+                               StructInfo structInfo = sw->StructInfo();
+                               size = structInfo.FFIType()->size;
+                               break;
+                             }
+                             default:
+                               break;
+                           }
+                         }
+                       }
+                     }
 
-            if (size == 0) {
-                throw NativeScriptException("Unknown type");
-            } else {
-                info.GetReturnValue().Set((double)size);
-            }
-        } catch (NativeScriptException& ex) {
-            ex.ReThrowToV8(isolate);
-        }
-    }).ToLocal(&func);
+                     if (size == 0) {
+                       throw NativeScriptException("Unknown type");
+                     } else {
+                       info.GetReturnValue().Set((double)size);
+                     }
+                   } catch (NativeScriptException& ex) {
+                     ex.ReThrowToV8(isolate);
+                   }
+                 }).ToLocal(&func);
 
-    Isolate* isolate = context->GetIsolate();
-    tns::Assert(success, isolate);
+  Isolate* isolate = context->GetIsolate();
+  tns::Assert(success, isolate);
 
-    success = interop->Set(context, tns::ToV8String(isolate, "sizeof"), func).FromMaybe(false);
-    tns::Assert(success, isolate);
+  success = interop->Set(context, tns::ToV8String(isolate, "sizeof"), func).FromMaybe(false);
+  tns::Assert(success, isolate);
 }
 
 const TypeEncoding* Interop::CreateEncoding(BinaryTypeEncodingType type) {
-    TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(calloc(1, sizeof(TypeEncoding)));
-    typeEncoding->type = type;
+  TypeEncoding* typeEncoding = reinterpret_cast<TypeEncoding*>(calloc(1, sizeof(TypeEncoding)));
+  typeEncoding->type = type;
 
-    return typeEncoding;
+  return typeEncoding;
 }
 
 Local<Value> Interop::HandleOf(Local<Context> context, Local<Value> value) {
-    Isolate* isolate = context->GetIsolate();
-    if (!value->IsNullOrUndefined()) {
-        if (value->IsArrayBuffer()) {
-            Local<ArrayBuffer> buffer = value.As<ArrayBuffer>();
-            std::shared_ptr<BackingStore> backingStore = buffer->GetBackingStore();
-            return Pointer::NewInstance(context, backingStore->Data());
-        } else if (value->IsArrayBufferView()) {
-            Local<ArrayBufferView> bufferView = value.As<ArrayBufferView>();
-            std::shared_ptr<BackingStore> backingStore = bufferView->Buffer()->GetBackingStore();
-            return Pointer::NewInstance(context, backingStore->Data());
-        } else if (value->IsObject()) {
-            Local<Object> obj = value.As<Object>();
-            if (BaseDataWrapper* wrapper = tns::GetValue(isolate, obj)) {
-                switch (wrapper->Type()) {
-                    case WrapperType::Primitive: {
-                        PrimitiveDataWrapper* pdw = static_cast<PrimitiveDataWrapper*>(wrapper);
-                        void* handle = pdw;
-                        return Pointer::NewInstance(context, handle);
-                    }
-                    case WrapperType::ObjCClass: {
-                        ObjCClassWrapper* cw = static_cast<ObjCClassWrapper*>(wrapper);
-                        @autoreleasepool {
-                            CFTypeRef ref = CFBridgingRetain(cw->Klass());
-                            void* handle = const_cast<void*>(ref);
-                            CFRelease(ref);
-                            return Pointer::NewInstance(context, handle);
-                        }
-                        break;
-                    }
-                    case WrapperType::ObjCProtocol: {
-                        ObjCProtocolWrapper* pw = static_cast<ObjCProtocolWrapper*>(wrapper);
-                        CFTypeRef ref = CFBridgingRetain(pw->Proto());
-                        void* handle = const_cast<void*>(ref);
-                        CFRelease(ref);
-                        return Pointer::NewInstance(context, handle);
-                    }
-                    case WrapperType::ObjCObject: {
-                        ObjCDataWrapper* w = static_cast<ObjCDataWrapper*>(wrapper);
-                        @autoreleasepool {
-                            id target = w->Data();
-                            CFTypeRef ref = CFBridgingRetain(target);
-                            void* handle = const_cast<void*>(ref);
-                            CFRelease(ref);
-                            return Pointer::NewInstance(context, handle);
-                        }
-                        break;
-                    }
-                    case WrapperType::Struct: {
-                        StructWrapper* w = static_cast<StructWrapper*>(wrapper);
-                        return Pointer::NewInstance(context, w->Data());
-                    }
-                    case WrapperType::Reference: {
-                        ReferenceWrapper* w = static_cast<ReferenceWrapper*>(wrapper);
-                        if (w->Value() != nullptr) {
-                            Local<Value> wrappedValue = w->Value()->Get(isolate);
-                            if (tns::GetValue(isolate, wrappedValue) == nullptr) {
-                                return Pointer::NewInstance(context, w->Value());
-                            }
-                            return HandleOf(context, wrappedValue);
-                        } else if (w->Data() != nullptr) {
-                            return Pointer::NewInstance(context, w->Data());
-                        }
-                        break;
-                    }
-                    case WrapperType::Pointer: {
-                        return value;
-                    }
-                    case WrapperType::Function: {
-                        FunctionWrapper* w = static_cast<FunctionWrapper*>(wrapper);
-                        const FunctionMeta* meta = w->Meta();
-                        void* handle = SymbolLoader::instance().loadFunctionSymbol(meta->topLevelModule(), meta->name());
-                        return Pointer::NewInstance(context, handle);
-                    }
-                    case WrapperType::FunctionReference: {
-                        FunctionReferenceWrapper* w = static_cast<FunctionReferenceWrapper*>(wrapper);
-                        if (w->Data() != nullptr) {
-                            return Pointer::NewInstance(context, w->Data());
-                        }
-                        break;
-                    }
-                    case WrapperType::Block: {
-                        BlockWrapper* blockWrapper = static_cast<BlockWrapper*>(wrapper);
-                        return Pointer::NewInstance(context, blockWrapper->Block());
-                    }
-                    default:
-                        break;
-                }
+  Isolate* isolate = context->GetIsolate();
+  if (!value->IsNullOrUndefined()) {
+    if (value->IsArrayBuffer() || value->IsArrayBufferView() || value->IsSharedArrayBuffer()) {
+      bool isArrayBuffer = false;
+      void* data = tns::TryGetBufferFromArrayBuffer(value, isArrayBuffer);
+      return Pointer::NewInstance(context, data);
+    } else if (value->IsObject()) {
+      Local<Object> obj = value.As<Object>();
+      if (BaseDataWrapper* wrapper = tns::GetValue(isolate, obj)) {
+        switch (wrapper->Type()) {
+          case WrapperType::Primitive: {
+            PrimitiveDataWrapper* pdw = static_cast<PrimitiveDataWrapper*>(wrapper);
+            void* handle = pdw;
+            return Pointer::NewInstance(context, handle);
+          }
+          case WrapperType::ObjCClass: {
+            ObjCClassWrapper* cw = static_cast<ObjCClassWrapper*>(wrapper);
+            @autoreleasepool {
+              CFTypeRef ref = CFBridgingRetain(cw->Klass());
+              void* handle = const_cast<void*>(ref);
+              CFRelease(ref);
+              return Pointer::NewInstance(context, handle);
             }
+            break;
+          }
+          case WrapperType::ObjCProtocol: {
+            ObjCProtocolWrapper* pw = static_cast<ObjCProtocolWrapper*>(wrapper);
+            CFTypeRef ref = CFBridgingRetain(pw->Proto());
+            void* handle = const_cast<void*>(ref);
+            CFRelease(ref);
+            return Pointer::NewInstance(context, handle);
+          }
+          case WrapperType::ObjCObject: {
+            ObjCDataWrapper* w = static_cast<ObjCDataWrapper*>(wrapper);
+            @autoreleasepool {
+              id target = w->Data();
+              CFTypeRef ref = CFBridgingRetain(target);
+              void* handle = const_cast<void*>(ref);
+              CFRelease(ref);
+              return Pointer::NewInstance(context, handle);
+            }
+            break;
+          }
+          case WrapperType::Struct: {
+            StructWrapper* w = static_cast<StructWrapper*>(wrapper);
+            return Pointer::NewInstance(context, w->Data());
+          }
+          case WrapperType::Reference: {
+            ReferenceWrapper* w = static_cast<ReferenceWrapper*>(wrapper);
+            if (w->Value() != nullptr) {
+              Local<Value> wrappedValue = w->Value()->Get(isolate);
+              if (tns::GetValue(isolate, wrappedValue) == nullptr) {
+                return Pointer::NewInstance(context, w->Value());
+              }
+              return HandleOf(context, wrappedValue);
+            } else if (w->Data() != nullptr) {
+              return Pointer::NewInstance(context, w->Data());
+            }
+            break;
+          }
+          case WrapperType::Pointer: {
+            return value;
+          }
+          case WrapperType::Function: {
+            FunctionWrapper* w = static_cast<FunctionWrapper*>(wrapper);
+            const FunctionMeta* meta = w->Meta();
+            void* handle =
+                SymbolLoader::instance().loadFunctionSymbol(meta->topLevelModule(), meta->name());
+            return Pointer::NewInstance(context, handle);
+          }
+          case WrapperType::FunctionReference: {
+            FunctionReferenceWrapper* w = static_cast<FunctionReferenceWrapper*>(wrapper);
+            if (w->Data() != nullptr) {
+              return Pointer::NewInstance(context, w->Data());
+            }
+            break;
+          }
+          case WrapperType::Block: {
+            BlockWrapper* blockWrapper = static_cast<BlockWrapper*>(wrapper);
+            return Pointer::NewInstance(context, blockWrapper->Block());
+          }
+          default:
+            break;
         }
-    } else if (value->IsNull()) {
-        return v8::Null(isolate);
+      }
     }
+  } else if (value->IsNull()) {
+    return v8::Null(isolate);
+  }
 
-    return Local<Value>();
+  return Local<Value>();
 }
 
-}
+}  // namespace tns

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -1,102 +1,113 @@
 #include "NSDataAdapter.h"
-#include "Helpers.h"
 #include "Caches.h"
+#include "Helpers.h"
 #include "IsolateWrapper.h"
 
 using namespace tns;
 using namespace v8;
 
 @implementation NSDataAdapter {
-    IsolateWrapper* wrapper_;
-    ObjCDataWrapper* dataWrapper_;
-    std::shared_ptr<Persistent<Value>> object_;
+  IsolateWrapper* wrapper_;
+  ObjCDataWrapper* dataWrapper_;
+  std::shared_ptr<Persistent<Value>> object_;
 }
 
 - (instancetype)initWithJSObject:(Local<Object>)jsObject isolate:(Isolate*)isolate {
-    if (self) {
-        tns::Assert(jsObject->IsArrayBuffer() || jsObject->IsArrayBufferView(), isolate);
-        self->wrapper_ = new IsolateWrapper(isolate);
-        self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
-        self->wrapper_->GetCache()->Instances.emplace(self, self->object_);
-        tns::SetValue(isolate, jsObject, (dataWrapper_ = new ObjCDataWrapper(self)));
-    }
+  if (self) {
+    tns::Assert(jsObject->IsArrayBuffer() || jsObject->IsArrayBufferView() ||
+                    jsObject->IsSharedArrayBuffer(),
+                isolate);
+    self->wrapper_ = new IsolateWrapper(isolate);
+    self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
+    self->wrapper_->GetCache()->Instances.emplace(self, self->object_);
+    tns::SetValue(isolate, jsObject, (dataWrapper_ = new ObjCDataWrapper(self)));
+  }
 
-    return self;
+  return self;
 }
 
 - (const void*)bytes {
-    return [self mutableBytes];
+  return [self mutableBytes];
 }
 
 - (void*)mutableBytes {
-    if (!wrapper_->IsValid()) {
-        return nil;
-    }
-    Isolate* isolate = wrapper_->Isolate();
-    Local<Object> obj = self->object_->Get(isolate).As<Object>();
-    if (obj->IsArrayBuffer()) {
-        void* data = obj.As<ArrayBuffer>()->GetBackingStore()->Data();
-        return data;
-    }
-
-    Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
-    if (bufferView->HasBuffer()) {
-        uint8_t* data = static_cast<uint8_t*>(bufferView->Buffer()->GetBackingStore()->Data());
-        if (data == nullptr) {
-            return nullptr;
-        }
-
-        return data + bufferView->ByteOffset();
-    }
-
-    size_t length = bufferView->ByteLength();
-    void* data = malloc(length);
-    bufferView->CopyContents(data, length);
-
+  if (!wrapper_->IsValid()) {
+    return nil;
+  }
+  Isolate* isolate = wrapper_->Isolate();
+  Local<Object> obj = self->object_->Get(isolate).As<Object>();
+  if (obj->IsArrayBuffer()) {
+    void* data = obj.As<ArrayBuffer>()->GetBackingStore()->Data();
     return data;
+  }
+
+  if (obj->IsSharedArrayBuffer()) {
+    void* data = obj.As<SharedArrayBuffer>()->GetBackingStore()->Data();
+    return data;
+  }
+
+  Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
+  if (bufferView->HasBuffer()) {
+    uint8_t* data = static_cast<uint8_t*>(bufferView->Buffer()->GetBackingStore()->Data());
+    if (data == nullptr) {
+      return nullptr;
+    }
+
+    return data + bufferView->ByteOffset();
+  }
+
+  size_t length = bufferView->ByteLength();
+  void* data = malloc(length);
+  bufferView->CopyContents(data, length);
+
+  return data;
 }
 
 - (NSUInteger)length {
-    if (!wrapper_->IsValid()) {
-        return 0;
-    }
-    Isolate* isolate = wrapper_->Isolate();
-    Local<Object> obj = self->object_->Get(isolate).As<Object>();
-    if (obj->IsArrayBuffer()) {
-        return obj.As<ArrayBuffer>()->ByteLength();
-    }
+  if (!wrapper_->IsValid()) {
+    return 0;
+  }
+  Isolate* isolate = wrapper_->Isolate();
+  Local<Object> obj = self->object_->Get(isolate).As<Object>();
+  if (obj->IsArrayBuffer()) {
+    return obj.As<ArrayBuffer>()->ByteLength();
+  }
 
-    return obj.As<ArrayBufferView>()->ByteLength();
+  if (obj->IsSharedArrayBuffer()) {
+    return obj.As<SharedArrayBuffer>()->ByteLength();
+  }
+
+  return obj.As<ArrayBufferView>()->ByteLength();
 }
 
 - (void)dealloc {
-    if (wrapper_->IsValid()) {
-        auto isolate = wrapper_->Isolate();
-        v8::Locker locker(isolate);
-        Isolate::Scope isolate_scope(isolate);
-        HandleScope handle_scope(isolate);
-        wrapper_->GetCache()->Instances.erase(self);
-        Local<Value> value = self->object_->Get(isolate);
-        BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-        if (wrapper != nullptr) {
-            tns::DeleteValue(isolate, value);
-            // ensure we don't delete the same wrapper twice
-            // this is just needed as a failsafe in case some other wrapper is assigned to this object
-            if (wrapper == dataWrapper_) {
-                dataWrapper_ = nullptr;
-            }
-            delete wrapper;
-        }
-        self->object_->Reset();
+  if (wrapper_->IsValid()) {
+    auto isolate = wrapper_->Isolate();
+    v8::Locker locker(isolate);
+    Isolate::Scope isolate_scope(isolate);
+    HandleScope handle_scope(isolate);
+    wrapper_->GetCache()->Instances.erase(self);
+    Local<Value> value = self->object_->Get(isolate);
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+    if (wrapper != nullptr) {
+      tns::DeleteValue(isolate, value);
+      // ensure we don't delete the same wrapper twice
+      // this is just needed as a failsafe in case some other wrapper is assigned to this object
+      if (wrapper == dataWrapper_) {
+        dataWrapper_ = nullptr;
+      }
+      delete wrapper;
     }
-    if (dataWrapper_ != nullptr) {
-        delete dataWrapper_;
-    }
-    
     self->object_->Reset();
-    delete self->wrapper_;
-    self->object_ = nullptr;
-    [super dealloc];
+  }
+  if (dataWrapper_ != nullptr) {
+    delete dataWrapper_;
+  }
+
+  self->object_->Reset();
+  delete self->wrapper_;
+  self->object_ = nullptr;
+  [super dealloc];
 }
 
 @end

--- a/TestRunner/app/tests/Marshalling/ObjCTypesTests.js
+++ b/TestRunner/app/tests/Marshalling/ObjCTypesTests.js
@@ -288,6 +288,33 @@ describe(module.id, function () {
         expect(source[4]).toEqual(52);
     });
 
+    it("should wrap a SharedArrayBuffer in NSData", function () {
+        var sab = new SharedArrayBuffer(4);
+        var view = new Uint8Array(sab);
+        view[0] = 49; view[1] = 50; view[2] = 51; view[3] = 52;
+
+        var result = TNSObjCTypes.alloc().init().methodWithNSData(sab);
+
+        expect(TNSGetOutput()).toBe('1234');
+        expect(result).toBe(sab);
+        TNSClearOutput();
+    });
+
+    it("should mutate a SharedArrayBuffer via NSMutableData", function () {
+        var sab = new SharedArrayBuffer(4);
+        var view = new Uint8Array(sab);
+        view[0] = 48; view[1] = 49; view[2] = 50; view[3] = 51;
+
+        var result = TNSObjCTypes.alloc().init().methodWithNSMutableData(sab);
+
+        expect(result).toBe(sab);
+        var after = new Uint8Array(sab);
+        expect(after[0]).toEqual(65);
+        expect(after[1]).toEqual(49);
+        expect(after[2]).toEqual(50);
+        expect(after[3]).toEqual(51);
+    });
+
     it("should be possible to wrap NSData in an ArrayBuffer", function () {
         var data = NSString.stringWithString("test").dataUsingEncoding(NSUTF8StringEncoding);
 
@@ -302,6 +329,35 @@ describe(module.id, function () {
         var arr = new ArrayBuffer(5);
         data.getBytes(arr);
         const actual = new Uint8Array(arr);
+        expect(actual[0]).toEqual(49);
+        expect(actual[1]).toEqual(50);
+        expect(actual[2]).toEqual(51);
+        expect(actual[3]).toEqual(52);
+        expect(actual[4]).toEqual(53);
+    });
+
+    it("should respect ArrayBufferView byteOffset when marshalling as void* parameter", () => {
+        var data = NSData.alloc().initWithBase64EncodedStringOptions("MTIzNDU=", NSDataBase64DecodingIgnoreUnknownCharacters);
+        var arr = new ArrayBuffer(7);
+        var prefill = new Uint8Array(arr);
+        prefill[0] = 65; prefill[5] = 66; prefill[6] = 67;
+        var view = new Uint8Array(arr, 1, 5);
+        data.getBytesLength(view, 5);
+        var result = new Uint8Array(arr);
+        expect(result[0]).toEqual(65);
+        expect(result[1]).toEqual(49);
+        expect(result[2]).toEqual(50);
+        expect(result[3]).toEqual(51);
+        expect(result[4]).toEqual(52);
+        expect(result[5]).toEqual(53);
+        expect(result[6]).toEqual(67);
+    });
+
+    it("should marshal a SharedArrayBuffer as void* parameter", () => {
+        var data = NSData.alloc().initWithBase64EncodedStringOptions("MTIzNDU=", NSDataBase64DecodingIgnoreUnknownCharacters);
+        var sab = new SharedArrayBuffer(5);
+        data.getBytes(sab);
+        var actual = new Uint8Array(sab);
         expect(actual[0]).toEqual(49);
         expect(actual[1]).toEqual(50);
         expect(actual[2]).toEqual(51);


### PR DESCRIPTION
The C++ interop path (TryGetBufferFromArrayBuffer) and several call sites
were not accounting for ArrayBufferView.byteOffset(), causing data
corruption when passing typed array views with non-zero offsets as void*
or incomplete array parameters. Additionally, SharedArrayBuffer was not
recognized anywhere in the runtime.

- Helpers.mm: TryGetBufferFromArrayBuffer now applies byteOffset and
  handles SharedArrayBuffer
- Interop.mm: IncompleteArrayEncoding now uses TryGetBufferFromArrayBuffer
  instead of inline buffer access; NSData wrapping and debug validation
  recognize SharedArrayBuffer
- InteropTypes.mm: HandleOf uses TryGetBufferFromArrayBuffer
- ArgConverter.mm: type matching recognizes SharedArrayBuffer
- NSDataAdapter.mm: mutableBytes, length, and init accept SharedArrayBuffer
