### PR TITLE
fix: Xcode 26.4 build for runtime, inspector, and metadata-generator

### DIFF
--- a/NativeScript/inspector/JsV8InspectorClient.mm
+++ b/NativeScript/inspector/JsV8InspectorClient.mm
@@ -22,6 +22,20 @@ using json = nlohmann::json;
 
 namespace v8_inspector {
 
+namespace {
+// Build an 8-bit `StringView` directly over a `std::string`'s storage.
+// V8 inspector messages on this side are ASCII/UTF-8 JSON, so the
+// previous `std::string -> std::vector<uint16_t> -> StringView` path
+// inflated each byte to two and then handed it to a 16-bit constructor.
+// Going straight through the 8-bit constructor avoids that doubling AND
+// dodges the libc++ deprecation that prompted the inspector's
+// `UChar = uint16_t -> char16_t` switch.
+StringView Make8BitStringView(const std::string& value) {
+  return StringView(reinterpret_cast<const uint8_t*>(value.data()),
+                    value.size());
+}
+}  // namespace
+
 #define NOTIFICATION(name)                                 \
   [[NSString stringWithFormat:@"%@:NativeScript.Debug.%s", \
                               [[NSBundle mainBundle] bundleIdentifier], name] UTF8String]
@@ -257,8 +271,7 @@ void JsV8InspectorClient::notify(const std::string& message) {
 }
 
 void JsV8InspectorClient::dispatchMessage(const std::string& message) {
-  std::vector<uint16_t> vector = tns::ToVector(message);
-  StringView messageView(vector.data(), vector.size());
+  StringView messageView = Make8BitStringView(message);
   Isolate* isolate = isolate_;
   v8::Locker locker(isolate);
   Isolate::Scope isolate_scope(isolate);
@@ -343,8 +356,7 @@ void JsV8InspectorClient::dispatchMessage(const std::string& message) {
       auto returnString = GetReturnMessageFromDomainHandlerResult(result, requestId);
 
       if (returnString.size() > 0) {
-        std::vector<uint16_t> vector = tns::ToVector(returnString);
-        StringView messageView(vector.data(), vector.size());
+        StringView messageView = Make8BitStringView(returnString);
         auto msg = StringBuffer::create(messageView);
         this->sendNotification(std::move(msg));
       }
@@ -486,8 +498,7 @@ void JsV8InspectorClient::inspectorSendEventCallback(const FunctionCallbackInfo<
   Local<v8::String> arg = args[0].As<v8::String>();
   std::string message = tns::ToString(isolate, arg);
 
-  std::vector<uint16_t> vector = tns::ToVector(message);
-  StringView messageView(vector.data(), vector.size());
+  StringView messageView = Make8BitStringView(message);
   auto msg = StringBuffer::create(messageView);
   client->sendNotification(std::move(msg));
 }

--- a/NativeScript/inspector/src/inspector/string-16.h
+++ b/NativeScript/inspector/src/inspector/string-16.h
@@ -17,7 +17,13 @@
 
 namespace v8_inspector {
 
-using UChar = uint16_t;
+// Xcode 26.x libc++ deprecates `std::basic_string<unsigned short>`
+// (and any `char_traits<T>` specialization for non-standard char types).
+// Switch to `char16_t` so `std::basic_string<UChar>` resolves to the
+// fully supported `std::u16string`. The V8 inspector public API still
+// takes `uint16_t*`, so call sites that cross that boundary now use
+// `reinterpret_cast` (see string-util.h).
+using UChar = char16_t;
 
 class String16 {
  public:

--- a/NativeScript/inspector/src/inspector/string-util.h
+++ b/NativeScript/inspector/src/inspector/string-util.h
@@ -30,13 +30,17 @@ class StringUtil {
   }
 
   static String fromUTF16LE(const uint16_t* data, size_t length) {
-    return String16::fromUTF16LE(data, length);
+    // V8 inspector protocol passes `uint16_t*` over its public API but
+    // `String16` is now backed by `std::u16string` (UChar = char16_t).
+    // The two are bit-identical 16-bit codepoints, so a reinterpret_cast
+    // is sound at the API boundary.
+    return String16::fromUTF16LE(reinterpret_cast<const UChar*>(data), length);
   }
 
   static const uint8_t* CharactersLatin1(const String& s) { return nullptr; }
   static const uint8_t* CharactersUTF8(const String& s) { return nullptr; }
   static const uint16_t* CharactersUTF16(const String& s) {
-    return s.characters16();
+    return reinterpret_cast<const uint16_t*>(s.characters16());
   }
   static size_t CharacterCount(const String& s) { return s.length(); }
 };

--- a/NativeScript/inspector/utils.mm
+++ b/NativeScript/inspector/utils.mm
@@ -35,16 +35,21 @@ std::string v8_inspector::GetMIMEType(std::string filePath) {
 }
 
 std::string v8_inspector::ToStdString(const StringView& value) {
-    std::vector<uint16_t> buffer(value.length());
+    // Build the std::u16string directly. The previous version went via
+    // std::vector<uint16_t> + a copy-construct into u16string, which on
+    // Xcode 26.x's libc++ tripped the `char_traits<unsigned short>`
+    // deprecation through the construct-from-iterator path. Writing
+    // char16_t straight into the destination avoids the
+    // non-standard char-traits specialization entirely.
+    std::u16string value16;
+    value16.resize(value.length());
     for (size_t i = 0; i < value.length(); i++) {
         if (value.is8Bit()) {
-            buffer[i] = value.characters8()[i];
+            value16[i] = static_cast<char16_t>(value.characters8()[i]);
         } else {
-            buffer[i] = value.characters16()[i];
+            value16[i] = static_cast<char16_t>(value.characters16()[i]);
         }
     }
-
-    std::u16string value16(buffer.begin(), buffer.end());
 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // FIXME: std::codecvt_utf8_utf16 is deprecated

--- a/NativeScript/v8runtime/V8Runtime.cpp
+++ b/NativeScript/v8runtime/V8Runtime.cpp
@@ -431,7 +431,12 @@ std::shared_ptr<const jsi::PreparedJavaScript> V8Runtime::prepareJavaScript(
 
 jsi::Value V8Runtime::evaluatePreparedJavaScript(
     const std::shared_ptr<const jsi::PreparedJavaScript>& js) {
-  return evaluateJavaScript(nullptr, nullptr);
+  // The second arg is a `std::string` sourceURL; newer Clang (Xcode 26.x)
+  // enforces `-Wnonnull` on its non-null `const char*` constructor, so we
+  // can no longer pass `nullptr`. Empty string is the documented "unknown
+  // source URL" value and matches the existing `prepareJavaScript` no-op
+  // (which already returns nullptr above).
+  return evaluateJavaScript(nullptr, "");
 }
 
 void V8Runtime::queueMicrotask(const jsi::Function& callback) {

--- a/metadata-generator/CMakeLists.txt
+++ b/metadata-generator/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(MetadataGenerator)
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -34,6 +35,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -target ${METADATA_BINARY_ARCH}-apple-da
 check_c_compiler_flag(-Wno-unused-but-set-variable HAS_UNUSED_BUT_SET_VARIABLE)
 if (HAS_UNUSED_BUT_SET_VARIABLE)
     add_compile_options(-Wno-unused-but-set-variable)
+endif()
+
+# Newer Apple toolchains (Xcode 26.x with Clang 17+) emit two diagnostics
+# inside LLVM 17.0.6's own headers (e.g. `-Wunnecessary-virtual-specifier`
+# on `virtual void anchor()` in classes declared `final` in
+# `clang/AST/Decl.h`, and `-Wpreferred-type-bitfield-enum-conversion` on
+# bitfield-to-enum stores). These are upstream-known issues that don't
+# affect generator behavior. Keep `-Werror` for *our* code, but downgrade
+# these two to warnings so the build succeeds without bumping LLVM.
+check_cxx_compiler_flag(-Wno-error=preferred-type-bitfield-enum-conversion HAS_NO_ERROR_PREFERRED_TYPE_BITFIELD_ENUM_CONVERSION)
+if (HAS_NO_ERROR_PREFERRED_TYPE_BITFIELD_ENUM_CONVERSION)
+    add_compile_options(-Wno-error=preferred-type-bitfield-enum-conversion)
+endif()
+
+check_cxx_compiler_flag(-Wno-error=unnecessary-virtual-specifier HAS_NO_ERROR_UNNECESSARY_VIRTUAL_SPECIFIER)
+if (HAS_NO_ERROR_UNNECESSARY_VIRTUAL_SPECIFIER)
+    add_compile_options(-Wno-error=unnecessary-virtual-specifier)
 endif()
 
 set(LLVM_LINKER_FLAGS "${LLVM_LINKER_FLAGS} ${LLVM_SYSTEM_LIBS} ${LLVM_LIBS}")


### PR DESCRIPTION
`metadata-generator/CMakeLists.txt`: downgrade two diagnostics from
errors to warnings. Both fire inside LLVM 17.0.6's own headers on
newer Apple toolchains and have no fix on our side:

* `-Wunnecessary-virtual-specifier` on `virtual void anchor()` inside
  classes declared `final` (e.g. `clang/AST/Decl.h:151`).
* `-Wpreferred-type-bitfield-enum-conversion` on bitfield-to-enum
  stores in clang AST headers.

The suppressions are guarded by `check_cxx_compiler_flag` so older
toolchains that don't recognize the flag names skip the
`add_compile_options` call cleanly.

## V8 JSI runtime
`NativeScript/v8runtime/V8Runtime.cpp`:
`evaluatePreparedJavaScript` was passing `nullptr` as the
`std::string sourceURL` argument. Clang 17's `-Wnonnull` rejects
implicit conversion from `nullptr` to the `std::string(const char*)`
constructor. The function body is unreachable in practice (the sibling
`prepareJavaScript` already returns `nullptr`), but it still has to
compile. Switch to `""` — the conventional "unknown source URL"
sentinel.

## V8 inspector — UChar / char_traits
libc++ in MacOSX26.4.sdk deprecates `std::char_traits<T>` for any
`T` other than the standard char family (`char`, `wchar_t`,
`char8_t`, `char16_t`, `char32_t`). `String16` is backed by
`std::basic_string<UChar>` with `using UChar = uint16_t;`, so every
inclusion of `<string>` after `string-16.h` instantiates
`char_traits<unsigned short>` and the whole inspector translation
unit fails under `-Werror,-Wdeprecated-declarations`.
Switch `UChar` to `char16_t`, which makes `std::basic_string<UChar>`
resolve to the fully supported `std::u16string`. The V8 inspector
public API surface still passes `uint16_t*` over its interfaces, so
`string-util.h` now uses `reinterpret_cast` at exactly those
boundaries — both directions are bit-identical 16-bit codepoints, so
the cast is sound.
`utils.mm::ToStdString` previously built a `std::vector<uint16_t>`
and then copy-constructed a `std::u16string` from that vector's
iterators. That iterator-range constructor pulled the deprecated
`char_traits<unsigned short>` back in through the back door. Rewrite
to write `char16_t` directly into the destination `std::u16string`,
dropping the intermediate vector.
`JsV8InspectorClient.mm`: add a file-local `Make8BitStringView`
helper that builds a `StringView` over a `std::string`'s storage as
an 8-bit (LATIN1/ASCII) view. Use it at the three sites that
previously inflated each ASCII/UTF-8 JSON byte into a `uint16_t`,
allocated a `std::vector<uint16_t>`, and then handed it to the
16-bit `StringView` constructor. The new path is shorter, allocates
nothing, and no longer touches the deprecated 16-bit string-traits
chain at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed compilation issues on newer Apple toolchains by adjusting compiler warning configurations.
  * Improved internal string handling for more reliable inspector protocol communications.

* **Performance**
  * Optimized message conversion in the debugger inspector, reducing intermediate data structure allocations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NativeScript/ios/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->