### PR TITLE
fix: enable interruption of V8 execution on Debugger.pause command

### DIFF
--- a/NativeScript/inspector/JsV8InspectorClient.mm
+++ b/NativeScript/inspector/JsV8InspectorClient.mm
@@ -128,6 +128,18 @@ void JsV8InspectorClient::onFrontendMessageReceived(const std::string& message) 
     dispatch_semaphore_signal(messageArrived_);
   });
 
+  // Debugger.pause needs to interrupt V8 even if the main thread is busy
+  // executing JS. RequestInterrupt fires at the next safe bytecode boundary.
+  auto parsed = json::parse(message, nullptr, false);
+  if (!parsed.is_discarded() && parsed.contains("method") && parsed["method"] == "Debugger.pause") {
+    isolate_->RequestInterrupt(
+        [](Isolate* isolate, void* data) {
+          auto client = static_cast<JsV8InspectorClient*>(data);
+          client->session_->schedulePauseOnNextStatement({}, {});
+        },
+        this);
+  }
+
   tns::ExecuteOnMainThread([this, message]() {
     dispatch_sync(this->messageLoopQueue_, ^{
       // prevent execution if we're already pumping messages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript pause functionality in the debugger to work reliably when called from DevTools. Pause commands now interrupt script execution consistently, regardless of main thread workload or application state. This enhancement provides developers with a more responsive and predictable debugging experience across all usage scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NativeScript/ios/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->