### PR TITLE
fix: close the inspector client socket on disconnect

### DIFF
--- a/NativeScript/inspector/InspectorServer.mm
+++ b/NativeScript/inspector/InspectorServer.mm
@@ -47,7 +47,7 @@ in_port_t InspectorServer::Init(
         dispatch_io_t channel =
             dispatch_io_create(DISPATCH_IO_STREAM, clientSocket, q, ^(int error) {
               if (error) {
-                NSLog(@"Error: %s", strerror(error));
+                NSLog(@"InspectorServer channel cleanup error: %s", strerror(error));
               }
               close(clientSocket);
             });
@@ -56,11 +56,12 @@ in_port_t InspectorServer::Init(
 
         __block dispatch_io_handler_t receiver = ^(bool done, dispatch_data_t data, int error) {
           if (error) {
-            NSLog(@"Error: %s", strerror(error));
+            NSLog(@"InspectorServer read message header error: %s", strerror(error));
           }
 
           const void* bytes = [(NSData*)data bytes];
           if (!bytes) {
+            dispatch_io_close(channel, DISPATCH_IO_STOP);
             return;
           }
 
@@ -73,7 +74,7 @@ in_port_t InspectorServer::Init(
           dispatch_io_read(channel, 0, length, q, ^(bool done, dispatch_data_t data, int error) {
             BOOL close = NO;
             if (error) {
-              NSLog(@"Error: %s", strerror(error));
+              NSLog(@"InspectorServer read message body error: %s", strerror(error));
               close = YES;
             }
 
@@ -102,7 +103,7 @@ in_port_t InspectorServer::Init(
           dispatch_io_read(channel, 0, 4, q, receiver);
         }
       } else {
-        NSLog(@"accept() failed;\n");
+        NSLog(@"InspectorServer accept() failed");
       }
     }
   });
@@ -143,7 +144,7 @@ void InspectorServer::Send(dispatch_io_t channel, dispatch_queue_t queue,
 
   dispatch_io_write(channel, 0, data, queue, ^(bool done, dispatch_data_t data, int error) {
     if (error) {
-      NSLog(@"Error: %s", strerror(error));
+      NSLog(@"InspectorServer::Send error: %s", strerror(error));
     }
   });
 }


### PR DESCRIPTION
The inspector's TCP server leaks a socket on every client disconnect.

When the debugger client closes the connection, the header read handler fires with an empty buffer and just returns:

```objc
const void* bytes = [(NSData*)data bytes];
if (!bytes) {
  return;
}
```

The dispatch_io channel is never closed there, so its cleanup handler never runs and the `close(clientSocket)` inside it never happens. Each connect/disconnect leaks one fd and one channel, which adds up across a debugging session with reconnects. Closing the channel on EOF lets the existing cleanup run.

I also relabeled the `NSLog(@"Error: %s", ...)` lines. Right now accept, header read, body read, send, and channel cleanup all log the same generic string, so you can't tell which stage actually failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved and standardized diagnostic error messages in the inspector server component. Messages are now more specific across connection handling, message header/body processing, connection acceptance, and message sending failures to aid troubleshooting without changing behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->