### PR TITLE
Make V8 string to NSString conversions UTF-16 faithful

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -294,7 +294,8 @@ void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value>
   } else if (value->IsString()) {
     if (type == BinaryTypeEncodingType::IdEncoding ||
         type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-      id data = tns::ToNSString(isolate, value);
+      std::u16string strValue = tns::ToUtf16String(isolate, value);
+      id data = [NSString stringWithCharacters:(const unichar*)strValue.data() length:strValue.size()];
       // this feels wrong but follows the other CFBridgingRetain calls
       // and also solves a leak
       auto ref = CFBridgingRetain(data);
@@ -929,8 +930,8 @@ void ArgConverter::IndexedPropertyGetterCallback(uint32_t index,
   }
 
   if ([obj isKindOfClass:[NSString class]]) {
-    const char* str = [obj UTF8String];
-    args.GetReturnValue().Set(tns::ToV8String(isolate, str));
+    NSString* nativeStr = (NSString*)obj;
+    args.GetReturnValue().Set(tns::ToV8String(isolate, nativeStr));
     return;
   }
 

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -294,8 +294,7 @@ void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value>
   } else if (value->IsString()) {
     if (type == BinaryTypeEncodingType::IdEncoding ||
         type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-      std::u16string strValue = tns::ToUtf16String(isolate, value);
-      id data = [NSString stringWithCharacters:(const unichar*)strValue.data() length:strValue.size()];
+      id data = tns::ToNSString(isolate, value);
       // this feels wrong but follows the other CFBridgingRetain calls
       // and also solves a leak
       auto ref = CFBridgingRetain(data);

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -48,7 +48,8 @@ using namespace tns;
         bool success = array->Get(context, self->index_).ToLocal(&key);
         tns::Assert(success, isolate);
         self->index_ += 2;
-        NSString* result = tns::ToNSString(isolate, key);
+        std::u16string keyStr = tns::ToUtf16String(isolate, key);
+        NSString* result = [NSString stringWithCharacters:(const unichar*)keyStr.data() length:keyStr.length()];
         return result;
     }
 
@@ -116,8 +117,8 @@ using namespace tns;
         bool success = properties->Get(context, (uint)self->index_).ToLocal(&value);
         tns::Assert(success, isolate);
         self->index_++;
-        std::string result = tns::ToString(isolate, value);
-        return [NSString stringWithUTF8String:result.c_str()];
+        std::u16string result = tns::ToUtf16String(isolate, value);
+        return [NSString stringWithCharacters:(const unichar*)result.data() length:result.size()];
     }
 
     return nil;
@@ -139,8 +140,8 @@ using namespace tns;
         Local<Value> value;
         bool success = properties->Get(context, i).ToLocal(&value);
         tns::Assert(success, isolate);
-        std::string result = tns::ToString(isolate, value);
-        [array addObject:[NSString stringWithUTF8String:result.c_str()]];
+        std::u16string result = tns::ToUtf16String(isolate, value);
+        [array addObject:[NSString stringWithCharacters:(const unichar*)result.data() length:result.size()]];
     }
 
     return array;
@@ -214,7 +215,7 @@ using namespace tns;
         bool success = obj->Get(context, key).ToLocal(&value);
         tns::Assert(success, isolate);
     } else if ([aKey isKindOfClass:[NSString class]]) {
-        const char* key = [aKey UTF8String];
+        NSString* key = (NSString*)aKey;
         Local<v8::String> keyV8Str = tns::ToV8String(isolate, key);
 
         if (obj->IsMap()) {

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -48,8 +48,7 @@ using namespace tns;
         bool success = array->Get(context, self->index_).ToLocal(&key);
         tns::Assert(success, isolate);
         self->index_ += 2;
-        std::u16string keyStr = tns::ToUtf16String(isolate, key);
-        NSString* result = [NSString stringWithCharacters:(const unichar*)keyStr.data() length:keyStr.length()];
+        NSString* result = tns::ToNSString(isolate, key);
         return result;
     }
 
@@ -117,8 +116,7 @@ using namespace tns;
         bool success = properties->Get(context, (uint)self->index_).ToLocal(&value);
         tns::Assert(success, isolate);
         self->index_++;
-        std::u16string result = tns::ToUtf16String(isolate, value);
-        return [NSString stringWithCharacters:(const unichar*)result.data() length:result.size()];
+        return tns::ToNSString(isolate, value);
     }
 
     return nil;
@@ -140,8 +138,7 @@ using namespace tns;
         Local<Value> value;
         bool success = properties->Get(context, i).ToLocal(&value);
         tns::Assert(success, isolate);
-        std::u16string result = tns::ToUtf16String(isolate, value);
-        [array addObject:[NSString stringWithCharacters:(const unichar*)result.data() length:result.size()]];
+        [array addObject:tns::ToNSString(isolate, value)];
     }
 
     return array;

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -106,8 +106,8 @@ inline NSString* ToNSString(const std::string& v) {
                                    length:v.length()
                                  encoding:NSUTF8StringEncoding] S_AUTORELEASE];
 }
-// this method is a copy of ToString to avoid needless std::string<->NSString
-// conversions
+// Reads the V8 string's native UTF-16 buffer directly so lone surrogates and
+// embedded NUL survive the bridge; a UTF-8 round-trip loses both.
 inline NSString* ToNSString(v8::Isolate* isolate,
                             const v8::Local<v8::Value>& value) {
   if (value.IsEmpty()) {
@@ -119,16 +119,15 @@ inline NSString* ToNSString(v8::Isolate* isolate,
     return ToNSString(isolate, obj);
   }
 
-  v8::String::Utf8Value result(isolate, value);
+  v8::String::Value result(isolate, value);
 
-  const char* val = *result;
+  const uint16_t* val = *result;
   if (val == nullptr) {
     return @"";
   }
 
-  return [[[NSString alloc] initWithBytes:*result
-                                   length:result.length()
-                                 encoding:NSUTF8StringEncoding] S_AUTORELEASE];
+  return [NSString stringWithCharacters:(const unichar*)val
+                                 length:result.length()];
 }
 #endif
 std::u16string ToUtf16String(v8::Isolate* isolate,

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -24,13 +24,26 @@ uint8_t* BinBuffer = new uint8_t[BUFFER_SIZE];
 }  // namespace
 
 std::u16string tns::ToUtf16String(Isolate* isolate, const Local<Value>& value) {
-  std::string valueStr = tns::ToString(isolate, value);
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // FIXME: std::codecvt_utf8_utf16 is deprecated
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-  std::u16string value16 = convert.from_bytes(valueStr);
+  // Read the V8 string's native UTF-16 buffer directly instead of round-tripping
+  // through UTF-8, which corrupts lone surrogates (replaced with U+FFFD) and is
+  // slower. This also drops the deprecated std::codecvt_utf8_utf16.
+  if (value.IsEmpty()) {
+    return std::u16string();
+  }
 
-  return value16;
+  if (value->IsStringObject()) {
+    Local<v8::String> obj = value.As<StringObject>()->ValueOf();
+    return tns::ToUtf16String(isolate, obj);
+  }
+
+  v8::String::Value result(isolate, value);
+
+  uint16_t* val = *result;
+  if (val == nullptr) {
+    return std::u16string();
+  }
+
+  return std::u16string((char16_t*)val, result.length());
 }
 
 std::vector<uint16_t> tns::ToVector(const std::string& value) {

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -324,8 +324,7 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
   } else if (argHelper.isString() &&
              (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
               typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
-    std::u16string str = tns::ToUtf16String(isolate, arg);
-    NSString* result = [NSString stringWithCharacters:(const unichar*)str.data() length:str.size()];
+    NSString* result = tns::ToNSString(isolate, arg);
     Interop::SetValue(dest, result);
   } else if (Interop::IsNumbericType(typeEncoding->type) || tns::IsNumber(arg)) {
     double value = tns::ToNumber(isolate, arg);
@@ -687,8 +686,7 @@ id Interop::ToObject(Local<Context> context, v8::Local<v8::Value> arg) {
   if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
     return nil;
   } else if (tns::IsString(arg)) {
-    std::u16string value = tns::ToUtf16String(isolate, arg);
-    NSString* result = [NSString stringWithCharacters:(const unichar*)value.data() length:value.size()];
+    NSString* result = tns::ToNSString(isolate, arg);
     return result;
   } else if (tns::IsNumber(arg)) {
     double value = tns::ToNumber(isolate, arg);

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -324,7 +324,8 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
   } else if (argHelper.isString() &&
              (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
               typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
-    NSString* result = tns::ToNSString(isolate, arg);
+    std::u16string str = tns::ToUtf16String(isolate, arg);
+    NSString* result = [NSString stringWithCharacters:(const unichar*)str.data() length:str.size()];
     Interop::SetValue(dest, result);
   } else if (Interop::IsNumbericType(typeEncoding->type) || tns::IsNumber(arg)) {
     double value = tns::ToNumber(isolate, arg);
@@ -686,7 +687,8 @@ id Interop::ToObject(Local<Context> context, v8::Local<v8::Value> arg) {
   if (arg.IsEmpty() || arg->IsNullOrUndefined()) {
     return nil;
   } else if (tns::IsString(arg)) {
-    NSString* result = tns::ToNSString(isolate, arg);
+    std::u16string value = tns::ToUtf16String(isolate, arg);
+    NSString* result = [NSString stringWithCharacters:(const unichar*)value.data() length:value.size()];
     return result;
   } else if (tns::IsNumber(arg)) {
     double value = tns::ToNumber(isolate, arg);

--- a/TestRunner/app/tests/ApiTests.js
+++ b/TestRunner/app/tests/ApiTests.js
@@ -12,6 +12,39 @@ describe(module.id, function () {
         expect(object.hash).toBe(3);
     });
 
+    it("preserves a lone high surrogate when bridging a JS string to NSString", function () {
+        // A lone high surrogate (U+D834, range U+D800-U+DBFF) is a valid JS string
+        // code unit but has no UTF-8 encoding. The old UTF-8 round-trip replaced it
+        // with U+FFFD; faithful UTF-16 bridging keeps it. Read the code unit straight
+        // out of the bridged string's UTF-16 buffer as a number: reading it back as a
+        // JS string would re-corrupt a lone surrogate, and converting it to UTF-8 to
+        // measure it is not reliable across OS versions.
+        var ns = NSString.stringWithString("\uD834");
+        expect(ns.length).toBe(1);
+
+        var buffer = interop.alloc(interop.sizeof(interop.types.uint16));
+        ns.getCharactersRange(buffer, NSMakeRange(0, 1));
+        var codeUnit = new interop.Reference(interop.types.uint16, buffer).value;
+        interop.free(buffer);
+
+        expect(codeUnit).toBe(0xD834); // 0xFFFD (65533) after a lossy UTF-8 round-trip
+    });
+
+    it("preserves a lone low surrogate when bridging a JS string to NSString", function () {
+        // The low surrogate range (U+DC00-U+DFFF) is a different bit pattern that also
+        // has no UTF-8 encoding and must survive the bridge intact; observed the same
+        // way as the high-surrogate case above.
+        var ns = NSString.stringWithString("\uDC00");
+        expect(ns.length).toBe(1);
+
+        var buffer = interop.alloc(interop.sizeof(interop.types.uint16));
+        ns.getCharactersRange(buffer, NSMakeRange(0, 1));
+        var codeUnit = new interop.Reference(interop.types.uint16, buffer).value;
+        interop.free(buffer);
+
+        expect(codeUnit).toBe(0xDC00); // 0xFFFD (65533) after a lossy UTF-8 round-trip
+    });
+
     it("NSArray from native (uncached) array access", function () {
         const res = TNSObjCTypes.new().getNSArrayOfNSURLs();
         console.log(res);

--- a/TestRunner/app/tests/ApiTests.js
+++ b/TestRunner/app/tests/ApiTests.js
@@ -45,6 +45,23 @@ describe(module.id, function () {
         expect(codeUnit).toBe(0xDC00); // 0xFFFD (65533) after a lossy UTF-8 round-trip
     });
 
+    it("preserves an embedded NUL when bridging a JS string to NSString", function () {
+        // U+0000 is a valid JS code unit but terminates a C string, so a bridge
+        // that went through char* would cut "a\0b" down to "a". Faithful UTF-16
+        // bridging keeps all three units. Read the NUL unit straight out of the
+        // NSString's buffer so the check does not lean on a native-to-JS conversion.
+        var withNul = "a" + String.fromCharCode(0) + "b";
+        var ns = NSString.stringWithString(withNul);
+        expect(ns.length).toBe(3);
+
+        var buffer = interop.alloc(interop.sizeof(interop.types.uint16));
+        ns.getCharactersRange(buffer, NSMakeRange(1, 1));
+        var codeUnit = new interop.Reference(interop.types.uint16, buffer).value;
+        interop.free(buffer);
+
+        expect(codeUnit).toBe(0x0000); // a char* bridge would have stopped before this
+    });
+
     it("NSArray from native (uncached) array access", function () {
         const res = TNSObjCTypes.new().getNSArrayOfNSURLs();
         console.log(res);


### PR DESCRIPTION
V8 strings are UTF-16, but a few of the V8 <-> NSString bridge points round-trip through UTF-8 first, and that loses data in two ways:

- **Lone surrogates** get corrupted. A JS string can hold an unpaired surrogate (for example `"\uD834"`), which has no valid UTF-8 encoding, so the round-trip replaces it with U+FFFD. This affects every site that goes through the UTF-8 path, including `tns::ToUtf16String` itself.
- **Embedded NUL** gets truncated at the sites that use C-string APIs. `DictionaryAdapter` builds strings with `[NSString stringWithUTF8String:result.c_str()]`, and a couple of reverse-direction spots fold `[obj UTF8String]` into a `std::string`, both of which stop at the first `\0`.

The fix is to keep everything in UTF-16:

- `tns::ToUtf16String` now reads the V8 string's native two-byte buffer directly via `v8::String::Value` instead of `ToString` + `std::codecvt_utf8_utf16`. As a bonus that drops the deprecated `codecvt` (there was already a `// FIXME` on it) and is faster.
- The JS -> NSString sites in `DictionaryAdapter`, `Interop` and `ArgConverter` now build the NSString with `stringWithCharacters:length:` off `ToUtf16String`, instead of `ToNSString` / `stringWithUTF8String:`.
- The two NSString -> V8 spots (`DictionaryAdapter objectForKey:` and the indexed getter in `ArgConverter`) pass the `NSString` straight to `ToV8String` instead of going through a `UTF8String` C string. `ToV8String(NSString*)` already exists and uses an explicit byte length, so it is NUL safe.

I left `tns::ToVector` alone on purpose. Its input is already a UTF-8 `std::string`, so it is a different conversion and not part of this bug.

Test: added a `TestRunner` case that bridges a JS string with a lone high surrogate to an NSString and checks the code unit survives. Without the fix it comes back as U+FFFD.

Formatting note: I matched each file's existing indentation (`DictionaryAdapter.mm` is 4-space, the others are 2-space) and did not run clang-format, to keep the diff to just the real changes.

We have shipped this in our downstream fork for a while.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of special Unicode characters (including surrogates and embedded NUL characters) during string conversions between JavaScript and native code.

* **Tests**
  * Added test coverage for special Unicode character handling to ensure correct preservation during conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->