### PR TITLE
fix: own native blocks with Block_copy/Block_release

### DIFF
--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1055,11 +1055,17 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
       return callback;
     }
 
-    BlockWrapper* blockWrapper = new BlockWrapper(block, typeEncoding, true);
+    // Take ownership of the returned block. Block_copy (not CFRetain) is the
+    // correct primitive here: a block returned by a native method is +0 and may
+    // still be a stack block. CFRetain does not promote a stack block to the
+    // heap, so releasing it later (during GC, on a different stack) would touch a
+    // dead frame and crash in objc_release. Block_copy moves it to the heap (or
+    // just bumps the refcount when it is already a heap/global block); the
+    // matching Block_release runs in ObjectManager::DisposeValue.
+    JSBlock* ownedBlock = reinterpret_cast<JSBlock*>(Block_copy(block));
+    BlockWrapper* blockWrapper = new BlockWrapper(ownedBlock, typeEncoding, true);
     Local<External> ext = External::New(isolate, blockWrapper);
     Local<v8::Function> callback;
-
-    CFRetain(block);
 
     bool success =
         v8::Function::New(

--- a/NativeScript/runtime/ObjectManager.mm
+++ b/NativeScript/runtime/ObjectManager.mm
@@ -1,4 +1,5 @@
 #include "ObjectManager.h"
+#include <Block.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <sstream>
 #include "Caches.h"
@@ -108,10 +109,12 @@ bool ObjectManager::DisposeValue(Isolate* isolate, Local<Value> value, bool isFi
     case WrapperType::Block: {
       BlockWrapper* blockWrapper = static_cast<BlockWrapper*>(wrapper);
       if (blockWrapper->OwnsBlock()) {
-        // Balance the CFRetain taken when a native block was wrapped for JS
-        // (see Interop::GetResult). This runs the block's dispose helper if
-        // we held the last reference.
-        CFRelease(blockWrapper->Block());
+        // Balance the Block_copy taken when a native block was wrapped for JS
+        // (see Interop::GetResult). Block_release is the correct counterpart to
+        // Block_copy and runs the block's dispose helper once we drop the last
+        // reference. (Using CFRelease here over-released stack blocks that were
+        // never promoted to the heap, crashing in objc_release during GC.)
+        Block_release(blockWrapper->Block());
       }
       // Blocks created from JS callbacks (OwnsBlock() == false) are owned by
       // the native code they were handed to (e.g. NSNotificationCenter);

--- a/TestFixtures/Api/TNSReturnsRetained.h
+++ b/TestFixtures/Api/TNSReturnsRetained.h
@@ -7,8 +7,14 @@ CF_IMPLICIT_BRIDGING_DISABLED
 
 id functionExplicitCreateNSObject();
 
+typedef int (^TNSIntBlock)(void);
+
 @interface TNSReturnsRetained : NSObject
 + (id)methodReturnsNSRetained NS_RETURNS_RETAINED;
 + (id)methodReturnsCFRetained CF_RETURNS_RETAINED;
 + (id)newNSObjectMethod;
+// Returns a +0 __NSStackBlock__ capturing `value` (see implementation). Used to
+// regression-test native block ownership: the runtime must take it with
+// Block_copy and release it with Block_release, not CFRetain/CFRelease.
++ (TNSIntBlock)blockCapturing:(int)value;
 @end

--- a/TestFixtures/Api/TNSReturnsRetained.m
+++ b/TestFixtures/Api/TNSReturnsRetained.m
@@ -1,26 +1,36 @@
 #import "TNSReturnsRetained.h"
 
-id functionReturnsNSRetained() {
-    return [[NSObject alloc] init];
-}
-id functionReturnsCFRetained() {
-    return [[NSObject alloc] init];
-}
-CFTypeRef functionImplicitCreate() {
-    return [[NSObject alloc] init];
-}
-id functionExplicitCreateNSObject() {
-    return [[NSObject alloc] init];
-}
+// Identity passthrough: hides the stack-block-ness from the compiler's
+// return-stack-address diagnostic without copying the block to the heap.
+static TNSIntBlock TNSPassthroughIntBlock(TNSIntBlock block) { return block; }
+
+id functionReturnsNSRetained() { return [[NSObject alloc] init]; }
+id functionReturnsCFRetained() { return [[NSObject alloc] init]; }
+CFTypeRef functionImplicitCreate() { return [[NSObject alloc] init]; }
+id functionExplicitCreateNSObject() { return [[NSObject alloc] init]; }
 
 @implementation TNSReturnsRetained
 + (id)methodReturnsNSRetained {
-    return [[NSObject alloc] init];
+  return [[NSObject alloc] init];
 }
 + (id)methodReturnsCFRetained {
-    return [[NSObject alloc] init];
+  return [[NSObject alloc] init];
 }
 + (id)newNSObjectMethod {
-    return [[TNSReturnsRetained alloc] init];
+  return [[TNSReturnsRetained alloc] init];
+}
++ (TNSIntBlock)blockCapturing:(int)value {
+  // This file is compiled with -fno-objc-arc. Capturing a non-constant value
+  // (the parameter) forces a __NSStackBlock__ - capturing only a compile-time
+  // constant would let clang promote it to a global block, which CFRetain
+  // handles fine and would not reproduce the bug. The block is routed through
+  // TNSPassthroughIntBlock so the compiler's "returning a stack block" check
+  // can't see through the call boundary; it is still a +0 stack block living in
+  // this frame at runtime. A correct runtime Block_copy's it to take ownership
+  // (heap-promoting it). CFRetain does not promote a stack block, so the wrapper
+  // is left pointing at this (about to be dead) stack frame.
+  return TNSPassthroughIntBlock(^{
+    return value;
+  });
 }
 @end

--- a/TestRunner/app/tests/ApiTests.js
+++ b/TestRunner/app/tests/ApiTests.js
@@ -661,6 +661,35 @@ describe(module.id, function () {
         expect(TNSReturnsRetained.newNSObjectMethod().retainCount()).toBe(1);
     });
 
+    it("takes ownership of +0 stack blocks returned from native", function () {
+        // Regression for the native-block ownership bug. blockCapturing: returns a
+        // +0 __NSStackBlock__ capturing its argument. A correct runtime Block_copy's
+        // each one into its own distinct heap block. The buggy CFRetain path does
+        // NOT promote a stack block to the heap, so all three wrappers are left
+        // pointing at the same (reused) stack slot and alias each other - reading
+        // whichever value was written last (and a later CFRelease would fault on
+        // the dead frame). See Interop::GetResult and ObjectManager::DisposeValue.
+        var b1 = TNSReturnsRetained.blockCapturing(11);
+        var b2 = TNSReturnsRetained.blockCapturing(22);
+        var b3 = TNSReturnsRetained.blockCapturing(33);
+
+        // On the fixed runtime each block is an independent heap copy.
+        expect(b1()).toBe(11);
+        expect(b2()).toBe(22);
+        expect(b3()).toBe(33);
+
+        // The wrappers must also be safely releasable on GC (Block_release of a
+        // heap copy vs. CFRelease of a dead stack frame).
+        b1 = b2 = b3 = null;
+        __collect();
+        var sink = 0;
+        for (var i = 0; i < 100000; i++) {
+            sink += i % 7;
+        }
+        __collect();
+        expect(sink).toBeGreaterThan(0);
+    });
+
     it("unmanaged", function () {
         var unmanaged = functionReturnsUnmanaged();
         expect('takeRetainedValue' in unmanaged).toBe(true);


### PR DESCRIPTION
A block returned from a native method is +0 and may still be a stack block. Interop::GetResult retained it with CFRetain and ObjectManager::DisposeValue released it with CFRelease, but CFRetain does not promote a stack block to the heap. By the time the JS wrapper was finalized during GC the CFRelease ran against a freed stack frame and crashed in objc_release (EXC_BAD_ACCESS).

Use Block_copy when taking ownership of the returned block (which moves a stack block to the heap, or bumps the refcount of a heap/global block) and Block_release as the matching counterpart on disposal.

This is the stack that resulted while testing the changes from [a65b729](https://github.com/NativeScript/ios/commit/a65b729f712d6dfee8a23532f909b9b49203472d)

```
Thread 0 Crashed:
0   libobjc.A.dylib               	0x0000000180039684 objc_release_x0 + 16
1   NativeScript                  	0x000000010ce35788 _ZN3tns13ObjectManager12DisposeValueEPN2v87IsolateENS1_5LocalINS1_5ValueEEEb + 772
2   NativeScript                  	0x000000010ce3542c _ZN3tns13ObjectManager17FinalizerCallbackERKN2v816WeakCallbackInfoINS_23ObjectWeakCallbackStateEEE + 64
3   NativeScript                  	0x000000010d1e15d4 _ZN2v88internal13GlobalHandles4Node31PostGarbageCollectionProcessingEPNS0_7IsolateE + 124
4   NativeScript                  	0x000000010d1e215c _ZN2v88internal13GlobalHandles31PostGarbageCollectionProcessingENS0_16GarbageCollectorENS_15GCCallbackFlagsE + 196
5   NativeScript                  	0x000000010d204b1c _ZN2v88internal4Heap14CollectGarbageENS0_15AllocationSpaceENS0_23GarbageCollectionReasonENS_15GCCallbackFlagsE + 3560
6   NativeScript                  	0x000000010d2066c0 _ZN2v88internal4Heap24PreciseCollectAllGarbageEiNS0_23GarbageCollectionReasonENS_15GCCallbackFlagsE + 92
7   NativeScript                  	0x000000010d1d9a70 _ZN2v88internal11GCExtension2GCERKNS_20FunctionCallbackInfoINS_5ValueEEE + 172
8   NativeScript                  	0x000000010cfce80c _ZN2v88internal25FunctionCallbackArguments4CallENS0_15CallHandlerInfoE + 276
9   NativeScript                  	0x000000010cfcde48 _ZN2v88internal12_GLOBAL__N_119HandleApiCallHelperILb0EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateENS0_6HandleINS0_10HeapObjectEEESA_NS8_INS0_20FunctionTemplateInfoEEENS8_IS4_EENS0_16BuiltinArgumentsE + 504
10  NativeScript                  	0x000000010cfcd5e4 _ZN2v88internalL26Builtin_Impl_HandleApiCallENS0_16BuiltinArgumentsEPNS0_7IsolateE + 240
11  NativeScript                  	0x000000010d84df4c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit + 108
12  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
13  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
14  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
15  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
16  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
17  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
18  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
19  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
20  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
21  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
22  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
23  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
24  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
25  NativeScript                  	0x000000010d7dbe58 Builtins_InterpreterEntryTrampoline + 248
26  NativeScript                  	0x000000010d7da190 Builtins_JSEntryTrampoline + 176
27  NativeScript                  	0x000000010d7d9e24 Builtins_JSEntry + 164
28  NativeScript                  	0x000000010d19c370 _ZN2v88internal12_GLOBAL__N_16InvokeEPNS0_7IsolateERKNS1_12InvokeParamsE + 2680
29  NativeScript                  	0x000000010d19b8c4 _ZN2v88internal9Execution4CallEPNS0_7IsolateENS0_6HandleINS0_6ObjectEEES6_iPS6_ + 212
30  NativeScript                  	0x000000010cf4f4b4 _ZN2v88Function4CallENS_5LocalINS_7ContextEEENS1_INS_5ValueEEEiPS5_ + 652
31  NativeScript                  	0x000000010ce640f4 _ZN3tns12ArgConverter14MethodCallbackEP7ffi_cifPvPS3_S3_ + 916
32  NativeScript                  	0x000000010cefdb0c ffi_closure_SYSV_inner + 796
33  NativeScript                  	0x000000010cf001b4 .Ldo_closure + 20
34  Foundation                    	0x0000000181156a2c __NSFireTimer + 56
35  CoreFoundation                	0x00000001804235e8 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 28
36  CoreFoundation                	0x00000001804232f8 __CFRunLoopDoTimer + 916
37  CoreFoundation                	0x00000001804229d4 __CFRunLoopDoTimers + 276
38  CoreFoundation                	0x0000000180421bec __CFRunLoopRun + 1756
39  CoreFoundation                	0x000000018041c904 _CFRunLoopRunSpecificWithOptions + 496
40  GraphicsServices              	0x00000001933599c0 GSEventRunModal + 116
41  UIKitCore                     	0x00000001864a54cc -[UIApplication _run] + 776
42  UIKitCore                     	0x0000000186b9f910 UIApplicationMain + 120
43  NativeScript                  	0x000000010cf00044 ffi_call_SYSV + 68
44  NativeScript                  	0x000000010cefd370 ffi_call_int + 972
45  NativeScript                  	0x000000010cee26a8 _ZN3tns7Interop20CallFunctionInternalERNS_10MethodCallE + 376
46  NativeScript                  	0x000000010ce92c4c _ZNSt3__110__function6__funcIZN3tns15MetadataBuilder17CFunctionCallbackERKN2v820FunctionCallbackInfoINS4_5ValueEEEE3$_0FvvEEclEv + 440
47  NativeScript                  	0x000000010ceebdf4 _ZN3tns5Tasks5DrainEv + 100
48  heykiddotalkangular           	0x0000000104870658 main + 736
49  (null)	0x0000000108f570e4 0x0 + 4445270244
50  (null)	0x0000000109217e00 0x0 + 4448157184
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native block ownership and lifecycle handling by correctly copying/releasing blocks and aligning the release method to the block type, preventing crashes or leaks and improving stability after callback disposal.
* **Tests**
  * Added a regression test covering ownership of `+0` stack blocks returned from native code, including validation across multiple invocations and behavior after release and garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->