### PR TITLE
fix: report the rejection reason when ES module evaluation fails

### DIFF
--- a/NativeScript/runtime/ModuleInternal.mm
+++ b/NativeScript/runtime/ModuleInternal.mm
@@ -885,11 +885,21 @@ Local<Value> ModuleInternal::LoadESModule(Isolate* isolate, const std::string& p
           if (state == Promise::kRejected) {
             RemoveModuleFromRegistry(canonicalPath);
             logPhase("evaluate", "promise-rejected");
+            if (!promiseTc.HasCaught()) {
+              // With top-level-await semantics, evaluation errors don't throw into
+              // the TryCatch — they surface only as the rejection reason of the
+              // evaluation promise. Re-throw the reason on the isolate so the
+              // TryCatch captures it and the exception below carries the original
+              // error message and stack trace instead of a synthetic placeholder.
+              isolate->ThrowException(promise->Result());
+            }
             if (promiseTc.HasCaught()) {
+              if (RuntimeConfig.IsDebug) {
+                Log(@"Error evaluating ES module (rejected promise): %s", canonicalPath.c_str());
+                tns::LogError(isolate, promiseTc);
+              }
               throw NativeScriptException(isolate, promiseTc, "Module evaluation promise rejected");
             } else {
-              Local<Value> reason = promise->Result();
-              isolate->ThrowException(reason);
               throw NativeScriptException(isolate, "Module evaluation promise rejected");
             }
           }


### PR DESCRIPTION
## What is the current behavior?

When an ES module graph fails during evaluation (e.g. a `ReferenceError` thrown at module scope), the app crashes with an opaque, layered error that never mentions the actual failure:

```
Error: Error in require() call:
  Requested module: './'
  ...
Original error:
Cannot instantiate module /app/bundle.mjs
Module evaluation promise rejected
NativeScriptException: Module evaluation promise rejected
File: (<unknown>:1:231)
```

The real error message and JS stack trace are nowhere in the output.

Root cause: with top-level-await semantics, `Module::Evaluate()` never throws evaluation errors synchronously — it returns a promise that rejects. The `kRejected` branch in `LoadESModule` fetched the real error via `promise->Result()` but never attached it to the thrown exception:

```cpp
Local<Value> reason = promise->Result();
isolate->ThrowException(reason);   // swallowed: promiseTc catches it and clears it on scope exit
throw NativeScriptException(isolate, "Module evaluation promise rejected");  // message-only constructor
```

The message-only `NativeScriptException` constructor fabricates a new `Error` from the fixed string, so every outer layer (instantiate of the importer, `require()` wrapper) re-wraps a placeholder while the original error is lost.

## What is the new behavior?

The rejection reason is re-thrown on the isolate *before* constructing the exception, so the still-active `TryCatch` captures it and the `NativeScriptException(isolate, TryCatch&, message)` constructor extracts the original error message and JS stack trace — the same treatment synchronous evaluation errors already get. Debug builds also log the error, mirroring the synchronous evaluation-failure path. The message-only fallback is kept in case the TryCatch has nothing (defensive; should not happen).

Example: a webpack ESM bundle whose evaluation throws `ReferenceError: NativeClass is not defined` now reports that message and the frame in the module graph where it was thrown, instead of the generic placeholder above.

Verified with `xcodebuild -scheme NativeScript -configuration Debug -sdk iphonesimulator build` (BUILD SUCCEEDED).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for module loading failures involving asynchronous initialization.
  * Error messages and stack traces now preserve the original rejection reason, making top-level-await failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->