### PR TITLE
fix(url): resync cached searchParams when search/href changes

### DIFF
--- a/NativeScript/runtime/js/blob-url.js
+++ b/NativeScript/runtime/js/blob-url.js
@@ -1,4 +1,6 @@
 const {
+    ArrayPrototypePush,
+    FunctionPrototypeCall,
     Map,
     MapPrototypeDelete,
     MapPrototypeGet,
@@ -39,35 +41,89 @@ InternalAccessor.getData = function (url) {
     return MapPrototypeGet(BLOB_STORE, url);
 };
 URL.InternalAccessor = InternalAccessor;
+
+// Pushes the params object's serialization onto its URL and records it as the
+// query string the params object is in sync with.
+function writeBack(params) {
+    const url = params._url;
+    url.search = params.toString();
+    url._searchParamsSource = url.search;
+}
+
+// Brings `params` back in line with its URL's current query string by mutating
+// it in place: url.searchParams is a same-object accessor, so the one params
+// object handed out for a URL has to survive every reparse of that URL. Only
+// the raw methods captured at construction are used here — the public ones are
+// wrapped to write back into the URL, which would clobber the very string being
+// applied.
+function resync(params) {
+    const url = params._url;
+    const search = url.search;
+    if (url._searchParamsSource === search) {
+        return;
+    }
+    const names = [];
+    FunctionPrototypeCall(params._forEach, params, function (value, name) {
+        ArrayPrototypePush(names, name);
+    });
+    for (let i = 0; i < names.length; i++) {
+        FunctionPrototypeCall(params._delete, params, names[i]);
+    }
+    const parsed = new URLSearchParamsCtor(search);
+    FunctionPrototypeCall(params._forEach, parsed, function (value, name) {
+        FunctionPrototypeCall(params._append, params, name, value);
+    });
+    url._searchParamsSource = search;
+}
+
 ObjectDefineProperty(URL.prototype, 'searchParams', {
     get() {
         if (this._searchParams == null) {
-            this._searchParams = new URLSearchParamsCtor(this.search);
-            ObjectDefineProperty(this._searchParams, '_url', {
+            const params = new URLSearchParamsCtor(this.search);
+            ObjectDefineProperty(this, '_searchParams', {
+                enumerable: false,
+                writable: true,
+                configurable: true,
+                value: params,
+            });
+            ObjectDefineProperty(this, '_searchParamsSource', {
+                enumerable: false,
+                writable: true,
+                configurable: true,
+                value: this.search,
+            });
+            ObjectDefineProperty(params, '_url', {
                 enumerable: false,
                 writable: false,
                 value: this,
             });
-            this._searchParams._append = this._searchParams.append;
-            this._searchParams.append = function (name, value) {
+            params._forEach = params.forEach;
+            params._append = params.append;
+            params.append = function (name, value) {
+                resync(this);
                 this._append(name, value);
-                this._url.search = this.toString();
+                writeBack(this);
             };
-            this._searchParams._delete = this._searchParams.delete;
-            this._searchParams.delete = function (name) {
+            params._delete = params.delete;
+            params.delete = function (name) {
+                resync(this);
                 this._delete(name);
-                this._url.search = this.toString();
+                writeBack(this);
             };
-            this._searchParams._set = this._searchParams.set;
-            this._searchParams.set = function (name, value) {
+            params._set = params.set;
+            params.set = function (name, value) {
+                resync(this);
                 this._set(name, value);
-                this._url.search = this.toString();
+                writeBack(this);
             };
-            this._searchParams._sort = this._searchParams.sort;
-            this._searchParams.sort = function () {
+            params._sort = params.sort;
+            params.sort = function () {
+                resync(this);
                 this._sort();
-                this._url.search = this.toString();
+                writeBack(this);
             };
+        } else {
+            resync(this._searchParams);
         }
         return this._searchParams;
     },

--- a/TestRunner/app/tests/ErrorEventsTests.js
+++ b/TestRunner/app/tests/ErrorEventsTests.js
@@ -67,8 +67,11 @@ describe("WHATWG error events", function () {
         expect(received.error).toBe(err);
         expect(received.message).toBe("x");
         // preventDefault() in the listener must suppress the __onUncaughtError shim.
+        // The hook is process-wide, so assert on this error rather than on the
+        // spy being empty: async failures from earlier suites can still drain
+        // into it while this test waits.
         afterQuietTurns(function () {
-            expect(uncaught.length).toBe(0);
+            expect(uncaught.indexOf(err)).toBe(-1);
             done();
         });
     });
@@ -154,7 +157,7 @@ describe("WHATWG error events", function () {
             expect(typeof received.reason.stackTrace).toBe("string");
             expect(received.reason.stackTrace.length).toBeGreaterThan(0);
             afterQuietTurns(function () {
-                expect(uncaught.length).toBe(0);
+                expect(uncaught.indexOf(reason)).toBe(-1);
                 done();
             });
         });
@@ -326,7 +329,7 @@ describe("WHATWG error events", function () {
         expect(received).not.toBeNull();
         expect(received.error).toBe(err);
         afterQuietTurns(function () {
-            expect(uncaught.length).toBe(0);
+            expect(uncaught.indexOf(err)).toBe(-1);
             done();
         });
     });

--- a/TestRunner/app/tests/UrlSearchParamsTests.js
+++ b/TestRunner/app/tests/UrlSearchParamsTests.js
@@ -1,0 +1,149 @@
+describe("URL.searchParams caching", function () {
+  it("returns the same object across reads", function () {
+    const url = new URL("https://example.com/?a=1");
+    expect(url.searchParams).toBe(url.searchParams);
+  });
+
+  it("parses the query string on the first read", function () {
+    const url = new URL("https://example.com/?a=1&b=2&b=3");
+    const sp = url.searchParams;
+    expect(sp.get("a")).toBe("1");
+    expect(sp.getAll("b")).toEqual(["2", "3"]);
+    expect(sp.size).toBe(3);
+  });
+
+  it("keeps the same object after assigning to search", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+    url.search = "?x=1";
+    expect(url.searchParams).toBe(sp);
+  });
+
+  it("refreshes after assigning to search", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+    expect(sp.get("a")).toBe("1");
+
+    url.search = "?b=2&c=3";
+
+    expect(url.searchParams.get("a")).toBe(null);
+    expect(url.searchParams.get("b")).toBe("2");
+    expect(url.searchParams.get("c")).toBe("3");
+    expect(url.searchParams.size).toBe(2);
+    expect(sp.get("b")).toBe("2");
+  });
+
+  it("refreshes after assigning to href", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+    expect(sp.get("a")).toBe("1");
+
+    url.href = "https://example.com/other?q=hello&lang=en";
+
+    expect(url.searchParams).toBe(sp);
+    expect(url.searchParams.get("a")).toBe(null);
+    expect(url.searchParams.get("q")).toBe("hello");
+    expect(url.searchParams.get("lang")).toBe("en");
+  });
+
+  it("refreshes to empty when the query is cleared", function () {
+    const url = new URL("https://example.com/?a=1&b=2");
+    const sp = url.searchParams;
+    expect(sp.size).toBe(2);
+
+    url.search = "";
+
+    expect(url.searchParams).toBe(sp);
+    expect(url.searchParams.size).toBe(0);
+    expect(url.searchParams.toString()).toBe("");
+  });
+
+  it("preserves duplicate keys when refreshing", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+
+    url.search = "?a=1&a=2&a=3";
+
+    expect(url.searchParams.getAll("a")).toEqual(["1", "2", "3"]);
+    expect(sp.getAll("a")).toEqual(["1", "2", "3"]);
+  });
+
+  it("writes mutations back to the url", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+
+    sp.set("a", "9");
+    expect(url.search).toBe("?a=9");
+
+    sp.append("b", "2");
+    expect(url.search).toBe("?a=9&b=2");
+    expect(url.href).toBe("https://example.com/?a=9&b=2");
+
+    sp.delete("a");
+    expect(url.search).toBe("?b=2");
+
+    sp.append("a", "0");
+    sp.sort();
+    expect(url.search).toBe("?a=0&b=2");
+  });
+
+  it("does not drop state on the read following a mutation", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+
+    sp.append("b", "2");
+    sp.append("b", "3");
+
+    const spAfter = url.searchParams;
+    expect(spAfter).toBe(sp);
+    expect(spAfter.getAll("b")).toEqual(["2", "3"]);
+    expect(spAfter.get("a")).toBe("1");
+    expect(spAfter.size).toBe(3);
+  });
+
+  it("interleaves mutations and direct assignments", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+
+    sp.set("a", "2");
+    url.search = "?b=1";
+
+    expect(url.searchParams.get("a")).toBe(null);
+    expect(url.searchParams.get("b")).toBe("1");
+
+    sp.set("c", "3");
+    expect(url.search).toBe("?b=1&c=3");
+    expect(url.searchParams.get("c")).toBe("3");
+  });
+
+  it("does not clobber a reassigned query when mutating a held reference", function () {
+    const url = new URL("https://example.com/?a=1");
+    const sp = url.searchParams;
+
+    url.search = "?b=1";
+    sp.set("c", "3");
+
+    expect(url.search).toBe("?b=1&c=3");
+    expect(sp.get("a")).toBe(null);
+  });
+
+  it("does not expose its cache as an enumerable property", function () {
+    const url = new URL("https://example.com/?a=1");
+    UNUSED(url.searchParams);
+    url.search = "?b=2";
+    UNUSED(url.searchParams);
+
+    const keys = Object.keys(url);
+    expect(keys.indexOf("_searchParams")).toBe(-1);
+    expect(keys.indexOf("_searchParamsSource")).toBe(-1);
+
+    const serialized = JSON.stringify(url);
+    expect(serialized.indexOf("_searchParams")).toBe(-1);
+    expect(serialized.indexOf("_searchParamsSource")).toBe(-1);
+
+    for (const key in url) {
+      expect(key).not.toBe("_searchParams");
+      expect(key).not.toBe("_searchParamsSource");
+    }
+  });
+});

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -140,6 +140,7 @@ require("./Timers");
 
 require("./URL");
 require("./URLSearchParams");
+require("./UrlSearchParamsTests");
 require("./URLPattern");
 
 // HTTP ESM Loader tests


### PR DESCRIPTION
Fixes two defects in `URL.prototype.searchParams` reported by CodeRabbit on #411: https://github.com/NativeScript/ios/pull/411#discussion_r3687911515

## The defects

1. **Staleness.** The getter cached a `URLSearchParams` built from the query string on first access. A later direct assignment to `url.search` or `url.href` did not refresh it, so subsequent `url.searchParams` reads returned parameters from the old query. Worse, mutating through a reference held across such an assignment wrote the stale set back onto the URL, silently discarding the newly assigned query.
2. **Enumeration leak.** The cache was stored as a plain enumerable own property, so `_searchParams` surfaced in `Object.keys(url)` and `JSON.stringify(url)`.

## Why resync in place instead of rebuilding

CodeRabbit's proposed diff rebuilds the cache into a **new** `URLSearchParams` when the recorded query no longer matches. That breaks the WHATWG same-object guarantee — `url.searchParams` must return the identical object for the URL's lifetime, and app code routinely holds a reference to it. A rebuild would leave every existing reference pointing at an object detached from its URL.

This PR keeps exactly one `URLSearchParams` per URL forever. When the recorded source string differs from the current `this.search`, the existing object is resynced in place: every key deleted, then re-appended from parsing the current query, then the recorded source updated. The resync goes through the raw methods captured at construction (`_append`, `_delete`, `_forEach`), never the public ones — those are wrapped to write back into `_url.search` and would clobber the very string being applied. The wrapped mutators also update the recorded source after writing back, so a mutation through the object never makes the next read look stale, and they resync first so a mutation on a reference held across a reassignment no longer clobbers the new query.

`_searchParams` and `_searchParamsSource` are defined non-enumerable via the destructured `ObjectDefineProperty`; all new intrinsic access goes through primordials (`ArrayPrototypePush`, `FunctionPrototypeCall`, both already captured — no additions to `primordials.js` or the eslint list were needed).

## Tests

New `TestRunner/app/tests/UrlSearchParamsTests.js` (12 specs), registered in `TestRunner/app/tests/index.js`:

- same-object identity across reads, and across a `url.search = ...` assignment
- refresh after `url.search` assignment, after `url.href` assignment, and when the query is cleared
- duplicate keys preserved across a refresh
- mutation write-back (`set`/`append`/`delete`/`sort` update `url.search` / `url.href`)
- mutation through the object does not trigger a resync that loses state on the next read
- mutating a held reference after a query reassignment does not clobber the new query
- `Object.keys(url)`, `JSON.stringify(url)` and `for..in` do not expose `_searchParams` / `_searchParamsSource`
- a fresh URL's first `searchParams` read parses correctly (including `getAll` and `size`)

## Drive-by: ErrorEvents spec hardening

Three specs in `ErrorEventsTests.js` asserted that **nothing at all** reached the process-wide `__onUncaughtError` hook during their quiet window. That is inherently order-dependent — an async failure from an earlier suite (the deliberate module-not-found in `NodeBuiltinsAndOptionalModulesTests.mjs`) can drain into the spy while the test waits, and the extra specs added here shifted timing enough to make it land there. They now assert that the specific error under test did not reach the hook, which is what they actually mean.

## Suite results

`./run_tests.sh` on the iOS simulator:

- baseline (`origin/main`): **922 tests, 0 failures**
- this branch: **934 tests, 0 failures**

ESLint (`npx eslint 'NativeScript/runtime/js/**/*.js'`) clean; `tools/js2c.mjs` regen clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `URL.searchParams` synchronization when URLs are updated through `search` or `href`.
  * Preserved stable parameter references while correctly reflecting query-string changes.
  * Ensured parameter mutations consistently update the associated URL.

* **Tests**
  * Added comprehensive coverage for caching, duplicate keys, empty queries, refresh behavior, and mutation synchronization.
  * Refined error-event tests to verify that prevented errors are excluded from uncaught-error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->