### PR TITLE
feat: scope worker-created extended class names to their isolate

### DIFF
--- a/NativeScript/runtime/ClassBuilder.cpp
+++ b/NativeScript/runtime/ClassBuilder.cpp
@@ -49,15 +49,17 @@ constexpr int kMaxConsecutiveAllocFailures = 100;
 
 // Moved this method in a separate .cpp file because ARC destroys the class
 // created with objc_allocateClassPair when the control leaves this method scope
-Class ClassBuilder::GetExtendedClass(std::string baseClassName,
-                                     std::string staticClassName,
-                                     std::string suffix) {
+Class ClassBuilder::GetExtendedClass(const std::string& baseClassName,
+                                     const std::string& staticClassName,
+                                     int isolateId) {
   Class baseClass = objc_getClass(baseClassName.c_str());
-  std::string name =
-      !staticClassName.empty()
-          ? staticClassName
-          : baseClassName + suffix + "_" +
-                std::to_string(++ClassBuilder::classNameCounter_);
+  std::string name = staticClassName;
+  if (name.empty()) {
+    name = baseClassName;
+    name += std::to_string(isolateId);
+    name += "__";
+    name += std::to_string(++ClassBuilder::classNameCounter_);
+  }
   // Allocation failure is the collision signal (objc_getClass beforehand
   // would race), but that only detects *registered* names — hence the lock
   // spanning allocate -> register.

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -27,9 +27,9 @@ class ClassBuilder {
  public:
   static v8::Local<v8::FunctionTemplate> GetExtendFunction(
       v8::Isolate* isolate, const InterfaceMeta* interfaceMeta);
-  static Class GetExtendedClass(std::string baseClassName,
-                                std::string staticClassName,
-                                std::string suffix);
+  static Class GetExtendedClass(const std::string& baseClassName,
+                                const std::string& staticClassName,
+                                int isolateId);
 
   static void RegisterBaseTypeScriptExtendsFunction(
       v8::Local<v8::Context> context);

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -17,6 +17,20 @@ using namespace v8;
 
 namespace tns {
 
+namespace {
+// Worker-created named classes must not claim process-global objc names:
+// verbatim names are the main isolate's contract (storyboards,
+// NSClassFromString and other name-based native lookups), and a worker
+// winning the registration race for one would nondeterministically demote the
+// main isolate's class to a collision suffix.
+std::string ScopeClassNameToIsolate(std::string name, int isolateId) {
+  if (!name.empty() && Runtime::IsWorker()) {
+    name += "_" + std::to_string(isolateId);
+  }
+  return name;
+}
+}  // namespace
+
 Local<FunctionTemplate> ClassBuilder::GetExtendFunction(Isolate* isolate,
                                                         const InterfaceMeta* interfaceMeta) {
   CacheItem* item = new CacheItem(interfaceMeta, nullptr);
@@ -62,8 +76,9 @@ void ClassBuilder::ExtendCallback(const FunctionCallbackInfo<Value>& info) {
     auto cache = Caches::Get(isolate);
     auto isolateId = cache->getIsolateId();
 
-    Class extendedClass = ClassBuilder::GetExtendedClass(baseClassName, staticClassName,
-                                                         std::to_string(isolateId) + "_");
+    Class extendedClass = ClassBuilder::GetExtendedClass(
+        baseClassName, ScopeClassNameToIsolate(staticClassName, isolateId),
+        std::to_string(isolateId) + "_");
     tns::Assert(extendedClass != nil, isolate);
     class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
     class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));
@@ -206,7 +221,8 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
 
         auto isolateId = cache->getIsolateId();
         __block Class extendedClass = ClassBuilder::GetExtendedClass(
-            baseClassName, extendedClassName, std::to_string(isolateId) + "_");
+            baseClassName, ScopeClassNameToIsolate(extendedClassName, isolateId),
+            std::to_string(isolateId) + "_");
         tns::Assert(extendedClass != nil, isolate);
         class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
         class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -23,11 +23,11 @@ namespace {
 // NSClassFromString and other name-based native lookups), and a worker
 // winning the registration race for one would nondeterministically demote the
 // main isolate's class to a collision suffix.
-std::string ScopeClassNameToIsolate(std::string name, int isolateId) {
+void ScopeClassNameToIsolate(std::string& name, int isolateId) {
   if (!name.empty() && Runtime::IsWorker()) {
-    name += "_" + std::to_string(isolateId);
+    name += '_';
+    name += std::to_string(isolateId);
   }
-  return name;
 }
 }  // namespace
 
@@ -76,9 +76,8 @@ void ClassBuilder::ExtendCallback(const FunctionCallbackInfo<Value>& info) {
     auto cache = Caches::Get(isolate);
     auto isolateId = cache->getIsolateId();
 
-    Class extendedClass = ClassBuilder::GetExtendedClass(
-        baseClassName, ScopeClassNameToIsolate(staticClassName, isolateId),
-        std::to_string(isolateId) + "_");
+    ScopeClassNameToIsolate(staticClassName, isolateId);
+    Class extendedClass = ClassBuilder::GetExtendedClass(baseClassName, staticClassName, isolateId);
     tns::Assert(extendedClass != nil, isolate);
     class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
     class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));
@@ -220,9 +219,9 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
         std::string extendedClassName = tns::ToString(isolate, extendedClassCtorFunc->GetName());
 
         auto isolateId = cache->getIsolateId();
-        __block Class extendedClass = ClassBuilder::GetExtendedClass(
-            baseClassName, ScopeClassNameToIsolate(extendedClassName, isolateId),
-            std::to_string(isolateId) + "_");
+        ScopeClassNameToIsolate(extendedClassName, isolateId);
+        __block Class extendedClass =
+            ClassBuilder::GetExtendedClass(baseClassName, extendedClassName, isolateId);
         tns::Assert(extendedClass != nil, isolate);
         class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
         class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));

--- a/TestRunner/app/tests/ExtendedClassNamingTests.js
+++ b/TestRunner/app/tests/ExtendedClassNamingTests.js
@@ -1,0 +1,40 @@
+describe("Extended class naming", function () {
+    it("keeps explicit main-isolate class names verbatim", function () {
+        var MainClaim = NSObject.extend({}, { name: "TNSMainVerbatimName" });
+        expect(NSStringFromClass(MainClaim)).toBe("TNSMainVerbatimName");
+    });
+
+    it("scopes worker-created explicit class names to their isolate", function (done) {
+        var worker = new Worker("~/shared/Workers/EvalWorker.js");
+        worker.onmessage = function (msg) {
+            worker.terminate();
+            var workerName = msg.data.name;
+            expect(workerName).not.toBe("TNSWorkerNameClaim");
+            expect(workerName.indexOf("TNSWorkerNameClaim")).toBe(0);
+            // The verbatim name must remain available to the main isolate.
+            var MainClass = NSObject.extend({}, { name: "TNSWorkerNameClaim" });
+            expect(NSStringFromClass(MainClass)).toBe("TNSWorkerNameClaim");
+            done();
+        };
+        worker.postMessage({
+            eval: "var C = NSObject.extend({}, { name: 'TNSWorkerNameClaim' }); " +
+                  "postMessage({ name: NSStringFromClass(C) });"
+        });
+    });
+
+    it("scopes worker-created TypeScript-extended class names to their isolate", function (done) {
+        var worker = new Worker("~/shared/Workers/EvalWorker.js");
+        worker.onmessage = function (msg) {
+            worker.terminate();
+            var workerName = msg.data.name;
+            expect(workerName).not.toBe("TNSWorkerTsNameClaim");
+            expect(workerName.indexOf("TNSWorkerTsNameClaim")).toBe(0);
+            done();
+        };
+        worker.postMessage({
+            eval: "function TNSWorkerTsNameClaim() {} " +
+                  "__extends(TNSWorkerTsNameClaim, NSObject); " +
+                  "postMessage({ name: NSStringFromClass(TNSWorkerTsNameClaim) });"
+        });
+    });
+});

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -168,6 +168,9 @@ require("./InspectTests");
 // The ns:/node: builtin modules
 require("./NsUtilTests");
 
+// Worker-isolate scoping of extended objc class names
+require("./ExtendedClassNamingTests");
+
 // Tests common for all runtimes (git submodule of NativeScript/common-runtime-tests-app).
 require("../shared/index").runAllTests();
 


### PR DESCRIPTION
Follow-up to #420 (proposed there as the by-construction hardening after the registration lock in #421).

## Problem

Named extends register the requested objc class name verbatim from **every** isolate, and the objc class namespace is process-global. A worker that extends a shared named class (e.g. `TimerTargetImpl` via `Infrastructure/timers`) before the main isolate does wins the registration race: the worker owns the bare name and the main isolate's class is nondeterministically demoted to a collision suffix (`TimerTargetImpl1`). Any name-based native lookup expecting the main isolate's class (`NSClassFromString`, storyboard class references, crash symbolication) then resolves the worker's. Cross-isolate contention for *fresh* same-named classes was also the trigger of the `+initialize` deadlock (#420) — serialized by #421's lock, now impossible to reach at all.

## Change

Named extends from **worker** isolates get `_<isolateId>` appended (`ScopeClassNameToIsolate`, applied on both extend paths — explicit-name `.extend()` and native `__extends`). Main-isolate names stay **byte-exact** — the user-facing contract — and are now deterministic regardless of worker startup order, since workers can no longer contend for them. Anonymous extends were already isolate-scoped.

**Behavior note:** native code resolving a *worker's* class by its exact declared name now finds the scoped name instead. Worker-created classes are internal to the worker model, so this is the isolation contract working as intended (and `NSStringFromClass` round-trips are unaffected — they use the actual registered name).

## Tests

New `ExtendedClassNamingTests` (registered in the runner):
- main-isolate explicit names stay verbatim;
- a worker's explicit-name class is scoped **and the verbatim name remains claimable by main afterwards** (the exact stolen-name defect this prevents);
- the TypeScript-`__extends` path scopes too.

Full local suite green (0 failures), including the three new specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented naming conflicts for Objective-C classes created in worker runtimes by automatically scoping their names to the worker isolate.
  * Preserved explicitly assigned class names in the main runtime.
* **Tests**
  * Added coverage for class naming across main and worker runtimes, including JavaScript- and TypeScript-extended classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->